### PR TITLE
Use empty configuration path in tests

### DIFF
--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -14,10 +14,13 @@ from pytest_qgis.qgis_interface import QgisInterface
 @pytest.fixture(autouse=True, scope="session")
 def qgis_app() -> QgsApplication:
     """Initializes qgis session for all tests"""
-    gui_flag = False
-    app = QgsApplication([], gui_flag)
+
+    app = QgsApplication([], GUIenabled=False)
     app.initQgis()
-    return app
+
+    yield app
+
+    app.exitQgis()
 
 
 @pytest.fixture(scope="session")

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
 import pytest
 from qgis.core import QgsApplication
 from qgis.gui import QgisInterface as QgisInterfaceOrig
@@ -10,9 +14,19 @@ from qgis.PyQt.QtWidgets import QWidget
 from pytest_qgis.mock_qgis_classes import MainWindow, MockMessageBar
 from pytest_qgis.qgis_interface import QgisInterface
 
+if TYPE_CHECKING:
+    from _pytest.tmpdir import TempPathFactory
+
+
+@pytest.fixture(scope="session")
+def tmp_qgis_config_path(tmp_path_factory: "TempPathFactory") -> Path:
+    config_path = tmp_path_factory.mktemp("qgis-test")
+    with patch.dict("os.environ", {"QGIS_CUSTOM_CONFIG_PATH": str(config_path)}):
+        yield config_path
+
 
 @pytest.fixture(autouse=True, scope="session")
-def qgis_app() -> QgsApplication:
+def qgis_app(tmp_qgis_config_path: "Path") -> QgsApplication:
     """Initializes qgis session for all tests"""
 
     app = QgsApplication([], GUIenabled=False)


### PR DESCRIPTION
- Use empty config path to make sure there are no existing profiles etc. interfering the tests.
- Close QgsApplication after tests are run.

Both are inspired by
https://github.com/qgis/QGIS/blob/498c52365d380f5a664dbb71961fd149fc1ad8c1/python/testing/__init__.py#L460