### PR TITLE
Use hook to patch the imported iface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This plugin makes it easier to write QGIS plugin tests with the help of some fix
 ### Hooks
 
 * `pytest_configure` hook is used to initialize and
-  configure [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html) as well as to
-  patch `qgis.utils.iface` with `qgis_iface`.
+  configure [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html). With QGIS >= 3.18 it is also
+  used to patch `qgis.utils.iface` with `qgis_iface` automatically.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pytest-qgis
+
 [![PyPI version](https://badge.fury.io/py/pytest-qgis.svg)](https://badge.fury.io/py/pytest-qgis)
 [![Downloads](https://img.shields.io/pypi/dm/pytest-qgis.svg)](https://pypistats.org/packages/pytest-qgis)
 ![CI](https://github.com/GispoCoding/pytest-qgis/workflows/CI/badge.svg)
@@ -7,27 +8,33 @@
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
-
 A [pytest](https://docs.pytest.org) plugin for testing QGIS python plugins.
-
 
 ## Features
 
-This plugin makes it easier to write QGIS plugin tests with the help of some fixtures:
+This plugin makes it easier to write QGIS plugin tests with the help of some fixtures and hooks:
 
-* `qgis_app` initializes and returns fully configured [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html). This fixture is called
-    automatically on the start of pytest session.
-* `qgis_canvas` initializes and returns [`QgsMapCanvas`](https://qgis.org/pyqgis/master/gui/QgsMapCanvas.html)
-* `qgis_iface` returns mocked [`QgsInterface`](https://qgis.org/pyqgis/master/gui/QgisInterface.html)
+### Fixtures
+
+* `qgis_app` returns and eventually exits fully
+  configured [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html). This fixture is called
+  automatically on the start of pytest session.
+* `qgis_canvas` returns [`QgsMapCanvas`](https://qgis.org/pyqgis/master/gui/QgsMapCanvas.html).
+* `qgis_iface` returns stubbed [`QgsInterface`](https://qgis.org/pyqgis/master/gui/QgisInterface.html)
 * `new_project` makes sure that all the map layers and configurations are removed. This should be used with tests that
-    add stuff to [`QgsProject`](https://qgis.org/pyqgis/master/core/QgsProject.html).
-* `qgis_processing` initializes the processing framework. This can be used when testing code that calls `processing.run(...)`.
+  add stuff to [`QgsProject`](https://qgis.org/pyqgis/master/core/QgsProject.html).
+* `qgis_processing` initializes the processing framework. This can be used when testing code that
+  calls `processing.run(...)`.
 
+### Hooks
+
+* `pytest_configure` hook is used to initialize and
+  configure [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html) as well as to
+  patch `qgis.utils.iface` with `qgis_iface`.
 
 ## Requirements
 
 This pytest plugin requires QGIS >= 3.10 to work.
-
 
 ## Installation
 
@@ -36,7 +43,6 @@ Install with `pip`:
 ```bash
 pip install pytest-qgis
 ```
-
 
 ## Contributing
 

--- a/src/pytest_qgis/mock_qgis_classes.py
+++ b/src/pytest_qgis/mock_qgis_classes.py
@@ -17,7 +17,7 @@
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from qgis.core import Qgis
 from qgis.PyQt.QtCore import QObject
@@ -45,9 +45,3 @@ class MockMessageBar(QObject):
         """A mocked method for pushing a message to the bar."""
         msg = f"{title}:{text}"
         self.messages[level].append(msg)
-
-
-class MainWindow(QObject):
-    def blockSignals(self, *args: Any) -> None:  # noqa N802
-        """Mocked blockSignals"""
-        pass

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -21,60 +21,49 @@
 
 import os.path
 import sys
-from pathlib import Path
-from typing import TYPE_CHECKING
-from unittest.mock import patch
+from typing import TYPE_CHECKING, Optional
 
 import pytest
+from _pytest.tmpdir import TempPathFactory
 from qgis.core import QgsApplication
 from qgis.gui import QgisInterface as QgisInterfaceOrig
 from qgis.gui import QgsMapCanvas
 from qgis.PyQt import QtCore, QtWidgets
 from qgis.PyQt.QtWidgets import QWidget
+from qgis.utils import iface  # noqa # This import is required
 
 from pytest_qgis.mock_qgis_classes import MainWindow, MockMessageBar
 from pytest_qgis.qgis_interface import QgisInterface
 
 if TYPE_CHECKING:
-    from _pytest.tmpdir import TempPathFactory
+    from _pytest.config import Config
 
-
-@pytest.fixture(scope="session")
-def tmp_qgis_config_path(tmp_path_factory: "TempPathFactory") -> Path:
-    config_path = tmp_path_factory.mktemp("qgis-test")
-    with patch.dict("os.environ", {"QGIS_CUSTOM_CONFIG_PATH": str(config_path)}):
-        yield config_path
+_APP: Optional[QgsApplication] = None
+_CANVAS: Optional[QgsMapCanvas] = None
+_IFACE: Optional[QgisInterface] = None
+_PARENT: Optional[QtWidgets.QWidget] = None
 
 
 @pytest.fixture(autouse=True, scope="session")
-def qgis_app(tmp_qgis_config_path: "Path") -> QgsApplication:
-    """Initializes qgis session for all tests"""
-
-    app = QgsApplication([], GUIenabled=False)
-    app.initQgis()
-
-    yield app
-
-    app.exitQgis()
+def qgis_app() -> QgsApplication:
+    yield _APP
+    assert _APP
+    _APP.exitQgis()
 
 
 @pytest.fixture(scope="session")
 def qgis_parent(qgis_app: QgsApplication) -> QWidget:
-    return QtWidgets.QWidget()
+    return _PARENT
 
 
 @pytest.fixture(scope="session")
-def qgis_canvas(qgis_parent: QWidget) -> QgsMapCanvas:
-    canvas = QgsMapCanvas(qgis_parent)
-    canvas.resize(QtCore.QSize(400, 400))
-    return canvas
+def qgis_canvas() -> QgsMapCanvas:
+    return _CANVAS
 
 
 @pytest.fixture(scope="session")
-def qgis_iface(qgis_canvas: QgsMapCanvas) -> QgisInterfaceOrig:
-    # QgisInterface is a stub implementation of the QGIS plugin interface
-    iface = QgisInterface(qgis_canvas, MockMessageBar(), MainWindow())
-    return iface
+def qgis_iface() -> QgisInterfaceOrig:
+    return _IFACE
 
 
 @pytest.fixture()
@@ -96,3 +85,27 @@ def qgis_processing(qgis_app: QgsApplication) -> None:
     from processing.core.Processing import Processing
 
     Processing.initialize()
+
+
+def pytest_configure(config: "Config") -> None:
+    """Initializes qgis session for all tests"""
+    global _APP, _CANVAS, _IFACE, _PARENT
+
+    # Use temporary path for QGIS config
+    tmp_path_factory = TempPathFactory.from_config(config)
+    config_path = tmp_path_factory.mktemp("qgis-test")
+    os.environ["QGIS_CUSTOM_CONFIG_PATH"] = str(config_path)
+
+    _APP = QgsApplication([], GUIenabled=False)
+    _APP.initQgis()
+
+    _PARENT = QtWidgets.QWidget()
+    _CANVAS = QgsMapCanvas(_PARENT)
+
+    _CANVAS.resize(QtCore.QSize(400, 400))
+
+    # QgisInterface is a stub implementation of the QGIS plugin interface
+    _IFACE = QgisInterface(_CANVAS, MockMessageBar(), MainWindow())
+
+    # Patching imported iface (evaluated as None in tests) with iface
+    sys.modules["qgis"].utils.iface = _IFACE  # type: ignore

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -31,7 +31,7 @@ from qgis.gui import QgsMapCanvas
 from qgis.PyQt import QtCore, QtWidgets
 from qgis.PyQt.QtWidgets import QWidget
 
-from pytest_qgis.mock_qgis_classes import MainWindow, MockMessageBar
+from pytest_qgis.mock_qgis_classes import MockMessageBar
 from pytest_qgis.qgis_interface import QgisInterface
 
 if TYPE_CHECKING:
@@ -109,7 +109,7 @@ def pytest_configure(config: "Config") -> None:
     _CANVAS.resize(QtCore.QSize(400, 400))
 
     # QgisInterface is a stub implementation of the QGIS plugin interface
-    _IFACE = QgisInterface(_CANVAS, MockMessageBar(), MainWindow())
+    _IFACE = QgisInterface(_CANVAS, MockMessageBar(), _PARENT)
 
     # Patching imported iface (evaluated as None in tests) with iface.
     # This only works with QGIS >= 3.18 since before that

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -22,6 +22,7 @@
 import os.path
 import sys
 from typing import TYPE_CHECKING, Optional
+from unittest import mock
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
@@ -118,4 +119,4 @@ def pytest_configure(config: "Config") -> None:
     if QGIS_VERSION >= 31800:
         from qgis.utils import iface  # noqa # This import is required
 
-        sys.modules["qgis"].utils.iface = _IFACE  # type: ignore
+        mock.patch("qgis.utils.iface", _IFACE).start()

--- a/tests/test_pytest_qgis.py
+++ b/tests/test_pytest_qgis.py
@@ -20,6 +20,11 @@ import pytest
 from qgis.core import Qgis, QgsProcessing, QgsProject, QgsVectorLayer
 from qgis.utils import iface
 
+try:
+    QGIS_VERSION = Qgis.versionInt()
+except AttributeError:
+    QGIS_VERSION = Qgis.QGIS_VERSION_INT
+
 # DO not use this directly, this is only meant to be used with
 # replace_iface_with_qgis_iface fixtrure
 __iface = None
@@ -81,5 +86,8 @@ def test_processing_run(qgis_processing):
     assert len(list(result["OUTPUT"].getFeatures())) > 0
 
 
+@pytest.mark.skipif(
+    QGIS_VERSION < 31800, reason="https://github.com/qgis/QGIS/issues/40564"
+)
 def test_setup_qgis_iface(qgis_iface):
     assert iface == qgis_iface

--- a/tests/test_pytest_qgis.py
+++ b/tests/test_pytest_qgis.py
@@ -18,6 +18,7 @@
 
 import pytest
 from qgis.core import Qgis, QgsProcessing, QgsProject, QgsVectorLayer
+from qgis.utils import iface
 
 # DO not use this directly, this is only meant to be used with
 # replace_iface_with_qgis_iface fixtrure
@@ -78,3 +79,7 @@ def test_processing_run(qgis_processing):
     assert isinstance(result["OUTPUT"], QgsVectorLayer)
     assert result["OUTPUT"].isValid()
     assert len(list(result["OUTPUT"].getFeatures())) > 0
+
+
+def test_setup_qgis_iface(qgis_iface):
+    assert iface == qgis_iface


### PR DESCRIPTION
This PR:
- Patches imported qgis.utils.iface with stubbed iface. Because of [this bug](https://github.com/qgis/QGIS/issues/40564), it is only used with QGIS >= 3.18.

Unfortunately this required initializing the QGIS inside inside the hook `pytest_configure` to ensure that the patching happens before running import clauses in the code.   