### PR TITLE
Add new dependecies to pinned requirements files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,13 @@ repos:
                 - flake8-annotations~=2.6.2
                 - flake8-qgis>=0.1.4
                 - flake8-pytest-style==1.5.0
+    - repo: https://github.com/jazzband/pip-tools
+      rev: 6.4.0
+      hooks:
+        - id: pip-compile
+          name: pip-compile setup.py
+          files: ^(setup\.py|requirements\.txt)$
+        - id: pip-compile
+          name: pip-compile requirements-dev.in
+          args: [requirements-dev.in]
+          files: ^requirements-dev\.(in|txt)$

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ Install with `pip`:
 pip install pytest-qgis
 ```
 
+## Development environment
+
+1. Create a virtual environment and activate it.
+2. `pip install pip-tools`
+3. `pip-sync requirements.txt requirements-dev.txt`
+
+### Updating dependencies
+
+1. `pip-compile --upgrade`
+2. `pip-compile --upgrade requirements-dev.in`
+
 ## Contributing
 
 Contributions are very welcome.

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,20 @@
-pip-tools
-pre-commit
-pytest-cov
+-c requirements.txt
+-e file:.
+
+# packaging
 twine
 wheel
+
+# testing
+pytest-cov
+
+# for linting checks at commit time
+pre-commit
+# for ide linting
+flake8
+black
+isort
+flake8-bugbear
+pep8-naming
+flake8-annotations
+flake8-qgis

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,34 +4,64 @@
 #
 #    pip-compile requirements-dev.in
 #
+-e file:.
+    # via -r requirements-dev.in
+astor==0.8.1
+    # via flake8-qgis
+atomicwrites==1.4.0
+    # via
+    #   -c requirements.txt
+    #   pytest
 attrs==21.2.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   flake8-bugbear
+    #   pytest
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+black==21.11b1
+    # via -r requirements-dev.in
 bleach==3.3.1
     # via readme-renderer
 certifi==2021.5.30
     # via requests
-cffi==1.14.6
-    # via cryptography
 cfgv==3.3.0
     # via pre-commit
 charset-normalizer==2.0.4
     # via requests
-click==8.0.1
-    # via pip-tools
+click==8.0.3
+    # via black
 colorama==0.4.4
-    # via twine
+    # via
+    #   -c requirements.txt
+    #   click
+    #   pytest
+    #   tqdm
+    #   twine
 coverage==5.5
     # via pytest-cov
-cryptography==3.4.7
-    # via secretstorage
 distlib==0.3.2
     # via virtualenv
 docutils==0.17.1
     # via readme-renderer
 filelock==3.0.12
     # via virtualenv
+flake8==4.0.1
+    # via
+    #   -r requirements-dev.in
+    #   flake8-annotations
+    #   flake8-bugbear
+    #   flake8-polyfill
+    #   flake8-qgis
+    #   pep8-naming
+flake8-annotations==2.7.0
+    # via -r requirements-dev.in
+flake8-bugbear==21.9.2
+    # via -r requirements-dev.in
+flake8-polyfill==1.0.2
+    # via pep8-naming
+flake8-qgis==1.0.0
+    # via -r requirements-dev.in
 identify==2.2.11
     # via pre-commit
 idna==3.2
@@ -41,47 +71,69 @@ importlib-metadata==4.6.3
     #   keyring
     #   twine
 iniconfig==1.1.1
-    # via pytest
-jeepney==0.7.1
     # via
-    #   keyring
-    #   secretstorage
+    #   -c requirements.txt
+    #   pytest
+isort==5.10.1
+    # via -r requirements-dev.in
 keyring==23.0.1
     # via twine
+mccabe==0.6.1
+    # via flake8
+mypy-extensions==0.4.3
+    # via black
 nodeenv==1.6.0
     # via pre-commit
 packaging==21.0
     # via
+    #   -c requirements.txt
     #   bleach
     #   pytest
-pep517==0.11.0
-    # via pip-tools
-pip-tools==6.2.0
+pathspec==0.9.0
+    # via black
+pep8-naming==0.12.1
     # via -r requirements-dev.in
 pkginfo==1.7.1
     # via twine
 platformdirs==2.2.0
-    # via virtualenv
+    # via
+    #   black
+    #   virtualenv
 pluggy==0.13.1
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 pre-commit==2.13.0
     # via -r requirements-dev.in
 py==1.10.0
-    # via pytest
-pycparser==2.20
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   pytest
+pycodestyle==2.8.0
+    # via flake8
+pyflakes==2.4.0
+    # via flake8
 pygments==2.9.0
     # via readme-renderer
 pyparsing==2.4.7
-    # via packaging
+    # via
+    #   -c requirements.txt
+    #   packaging
 pytest==6.2.4
-    # via pytest-cov
+    # via
+    #   -c requirements.txt
+    #   pytest-cov
+    #   pytest-qgis
 pytest-cov==2.12.1
     # via -r requirements-dev.in
+pywin32-ctypes==0.2.0
+    # via keyring
 pyyaml==5.4.1
     # via pre-commit
 readme-renderer==29.0
     # via twine
+regex==2021.11.10
+    # via black
 requests==2.26.0
     # via
     #   requests-toolbelt
@@ -90,8 +142,6 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==1.5.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -99,15 +149,18 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via
+    #   -c requirements.txt
     #   pre-commit
     #   pytest
     #   pytest-cov
-tomli==1.2.0
-    # via pep517
+tomli==1.2.2
+    # via black
 tqdm==4.62.0
     # via twine
 twine==3.4.2
     # via -r requirements-dev.in
+typing-extensions==4.0.0
+    # via black
 urllib3==1.26.6
     # via requests
 virtualenv==20.7.0
@@ -115,12 +168,6 @@ virtualenv==20.7.0
 webencodings==0.5.1
     # via bleach
 wheel==0.36.2
-    # via
-    #   -r requirements-dev.in
-    #   pip-tools
+    # via -r requirements-dev.in
 zipp==3.5.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip
-# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,11 @@
 #
 #    pip-compile
 #
+atomicwrites==1.4.0
+    # via pytest
 attrs==21.2.0
+    # via pytest
+colorama==0.4.4
     # via pytest
 iniconfig==1.1.1
     # via pytest


### PR DESCRIPTION
Pytest added new dependencies that were not specified in the requirements.txt. Somehow I got into situation that new pytest was installed without installing its dependency atomicwrites and tests failed.

- Add new pytest dependecies to the pinned
requirements files.
- Add linting dev-dependencies so linting can be used in IDEs.
- Add also the package itself to the dev-requirements so it is findable
when running pytests.
- Specify requirements.txt as constraints for dev-requirements.
- Update README.md regarding dependecies