### PR TITLE
Use QgsLayerTreeMapCanvasBridge to keep the layer order correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ This plugin makes it easier to write QGIS plugin tests with the help of some fix
 
 ### Markers
 
-* `qgis_show_map` lets developer inspect the QGIS map visually at the teardown of the test.  **NOTE**: This marker is
-  still experimental and layer order might differ if using layers with different coordinate systems. Full signature of
+* `qgis_show_map` lets developer inspect the QGIS map visually at the teardown of the test. Full signature of
   the marker is:
   ```python
   @pytest.mark.qgis_show_map(timeout: int = 30, add_basemap: bool = False, zoom_to_common_extent: bool = True, extent: QgsRectangle = None)

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -33,7 +33,7 @@ import pytest
 from _pytest.tmpdir import TempPathFactory
 from qgis.core import Qgis, QgsApplication, QgsProject, QgsRectangle, QgsVectorLayer
 from qgis.gui import QgisInterface as QgisInterfaceOrig
-from qgis.gui import QgsGui, QgsMapCanvas
+from qgis.gui import QgsGui, QgsLayerTreeMapCanvasBridge, QgsMapCanvas
 from qgis.PyQt import QtCore, QtWidgets
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QMessageBox, QWidget
@@ -322,6 +322,9 @@ def _configure_qgis_map(
     tmp_path: Path,
 ) -> None:
     message_box = QMessageBox(qgis_parent)
+    bridge = QgsLayerTreeMapCanvasBridge(  # noqa: F841, this needs to be assigned
+        QgsProject.instance().layerTreeRoot(), qgis_iface.mapCanvas()
+    )
     try:
         # Change project CRS to most common CRS if it is not set
         if not QgsProject.instance().crs().isValid():

--- a/src/pytest_qgis/utils.py
+++ b/src/pytest_qgis/utils.py
@@ -171,8 +171,6 @@ def copy_layer_style_and_position(
         layer_tree_layer.name()
     ]
 
-    # TODO: it does not seem to matter how this is used.
-    #  All new layers appear at he bottom...
     group.insertLayer(index + 1, layer2)
 
 

--- a/tests/visual/test_show_map.py
+++ b/tests/visual/test_show_map.py
@@ -61,6 +61,19 @@ def test_show_map_crs_change_to_3067(
     QgsProject.instance().addMapLayers([layer_polygon, layer_polygon_3067, raster_3067])
 
 
+@pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT)
+@pytest.mark.skipif(
+    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+)
+def test_show_map_crs_change_to_3067_with_different_layer_order(
+    layer_polygon, layer_polygon_3067, raster_3067, qgis_version
+):
+    layer_polygon_3067.setOpacity(0.3)
+    if qgis_version > 31800:
+        raster_3067.setOpacity(0.9)
+    QgsProject.instance().addMapLayers([raster_3067, layer_polygon_3067, layer_polygon])
+
+
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT, add_basemap=True)
 @pytest.mark.skipif(
     QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
@@ -83,7 +96,7 @@ def test_show_map_crs_change_to_4326(
 ):
     if qgis_version > 31800:
         raster_3067.setOpacity(0.9)
-    QgsProject.instance().addMapLayers([layer_points, raster_3067, layer_polygon])
+    QgsProject.instance().addMapLayers([layer_points, layer_polygon, raster_3067])
 
 
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT)


### PR DESCRIPTION
This PR:
- Fixes the bug of wrong layer ordering when using `@pytest.mark.qgis_show_map` with layers with different coordinate systems.

Inspired by this [gist](https://gist.github.com/ThomasG77/f711853e5fb81c746d2a1af0b2a9ecf5) made by @ThomasG77.