### PR TITLE
Add QgisBot to make it easier to access utility functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This plugin makes it easier to write QGIS plugin tests with the help of some fix
 * `qgis_app` returns and eventually exits fully
   configured [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html). This fixture is called
   automatically on the start of pytest session.
-* `qgis_bot` returns a [`QgisBot`](#qgisbot), which holds common utility methods for interacting with QGIS.
+* `qgis_bot` returns a [`QgisBot`](#qgisbot), which holds common utility methods for interacting with QGIS. Also
+  fixture `module_qgis_bot` in module scope is provided.
 * `qgis_canvas` returns [`QgsMapCanvas`](https://qgis.org/pyqgis/master/gui/QgsMapCanvas.html).
 * `qgis_parent` returns the QWidget used as parent of the `qgis_canvas`
 * `qgis_iface` returns stubbed [`QgsInterface`](https://qgis.org/pyqgis/master/gui/QgisInterface.html)

--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ markers can be used.
 
    ```
 
-* `get_qgs_attribute_dialog_widgets_by_name` function can be used to get dictionary of the `QgsAttributeDialog` widgets.
-  Check the test [test_qgis_ui.py::test_attribute_dialog_change](./tests/visual/test_qgis_ui.py) for a usage example.
-
 ### Hooks
 
 * `pytest_configure` hook is used to initialize and
@@ -95,6 +92,8 @@ Class to hold common utility methods for interacting with QGIS. Here are some of
 
 * `create_feature_with_attribute_dialog` method to create a feature with default values using QgsAttributeDialog. This
   ensures that all the default values are honored and for example boolean fields are either true or false, not null.
+* `get_qgs_attribute_dialog_widgets_by_name` function can be used to get dictionary of the `QgsAttributeDialog` widgets.
+  Check the test [test_qgis_ui.py::test_attribute_dialog_change](./tests/visual/test_qgis_ui.py) for a usage example.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This plugin makes it easier to write QGIS plugin tests with the help of some fix
 * `qgis_app` returns and eventually exits fully
   configured [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html). This fixture is called
   automatically on the start of pytest session.
+* `qgis_bot` returns a [`QgisBot`](#qgisbot), which holds common utility methods for interacting with QGIS.
 * `qgis_canvas` returns [`QgsMapCanvas`](https://qgis.org/pyqgis/master/gui/QgsMapCanvas.html).
 * `qgis_parent` returns the QWidget used as parent of the `qgis_canvas`
 * `qgis_iface` returns stubbed [`QgsInterface`](https://qgis.org/pyqgis/master/gui/QgisInterface.html)
@@ -33,8 +34,8 @@ This plugin makes it easier to write QGIS plugin tests with the help of some fix
 
 ### Markers
 
-* `qgis_show_map` lets developer inspect the QGIS map visually at the teardown of the test. Full signature of
-  the marker is:
+* `qgis_show_map` lets developer inspect the QGIS map visually at the teardown of the test. Full signature of the marker
+  is:
   ```python
   @pytest.mark.qgis_show_map(timeout: int = 30, add_basemap: bool = False, zoom_to_common_extent: bool = True, extent: QgsRectangle = None)
   ```
@@ -87,6 +88,13 @@ markers can be used.
   option `--qgis_disable_gui` will override this.
 * `qgis_canvas_width` width of the QGIS canvas in pixels. Defaults to 600.
 * `qgis_canvas_height` height of the QGIS canvas in pixels. Defaults to 600.
+
+## QgisBot
+
+Class to hold common utility methods for interacting with QGIS. Here are some of the methods:
+
+* `create_feature_with_attribute_dialog` method to create a feature with default values using QgsAttributeDialog. This
+  ensures that all the default values are honored and for example boolean fields are either true or false, not null.
 
 ## Requirements
 

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -235,6 +235,14 @@ def qgis_bot() -> QgisBot:
     return QgisBot()
 
 
+@pytest.fixture(scope="module")
+def module_qgis_bot() -> QgisBot:
+    """
+    Object that holds common utility methods for interacting with QGIS.
+    """
+    return QgisBot()
+
+
 @pytest.fixture(autouse=True)
 def qgis_show_map(
     qgis_app: QgsApplication,

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -228,19 +228,19 @@ def qgis_countries_layer(qgis_world_map_geopackage: Path) -> QgsVectorLayer:
 
 
 @pytest.fixture()
-def qgis_bot() -> QgisBot:
+def qgis_bot(qgis_iface: QgisInterface) -> QgisBot:
     """
     Object that holds common utility methods for interacting with QGIS.
     """
-    return QgisBot()
+    return QgisBot(qgis_iface)
 
 
 @pytest.fixture(scope="module")
-def module_qgis_bot() -> QgisBot:
+def module_qgis_bot(qgis_iface: QgisInterface) -> QgisBot:
     """
     Object that holds common utility methods for interacting with QGIS.
     """
-    return QgisBot()
+    return QgisBot(qgis_iface)
 
 
 @pytest.fixture(autouse=True)

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -39,6 +39,7 @@ from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QMainWindow, QMessageBox, QWidget
 
 from pytest_qgis.mock_qgis_classes import MockMessageBar
+from pytest_qgis.qgis_bot import QgisBot
 from pytest_qgis.qgis_interface import QgisInterface
 from pytest_qgis.utils import (
     clean_qgis_layer,
@@ -224,6 +225,14 @@ def qgis_countries_layer(qgis_world_map_geopackage: Path) -> QgsVectorLayer:
     Natural Earth countries as a QgsVectorLayer.
     """
     return _get_countries_layer(qgis_world_map_geopackage)
+
+
+@pytest.fixture()
+def qgis_bot() -> QgisBot:
+    """
+    Object that holds common utility methods for interacting with QGIS.
+    """
+    return QgisBot()
 
 
 @pytest.fixture(autouse=True)

--- a/src/pytest_qgis/qgis_bot.py
+++ b/src/pytest_qgis/qgis_bot.py
@@ -87,7 +87,6 @@ class QgisBot:
         # Two accepts to bypass some warnings
         dialog.accept()
         dialog.accept()
-        layer.commitChanges()
 
         feature_ids = set(layer.allFeatureIds())
         feature_id = list(feature_ids.difference(initial_ids))

--- a/src/pytest_qgis/qgis_bot.py
+++ b/src/pytest_qgis/qgis_bot.py
@@ -1,0 +1,95 @@
+#  Copyright (C) 2021-2022 pytest-qgis Contributors.
+#
+#
+#  This file is part of pytest-qgis.
+#
+#  pytest-qgis is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  pytest-qgis is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
+#
+from typing import Any, Dict, Optional
+
+from qgis.core import (
+    QgsFeature,
+    QgsGeometry,
+    QgsVectorDataProvider,
+    QgsVectorLayer,
+    QgsVectorLayerUtils,
+)
+from qgis.gui import QgsAttributeDialog, QgsAttributeEditorContext
+
+
+class QgisBot:
+    """
+    Class to hold common utility methods for interacting with QIGS.
+    """
+
+    def __init__(self) -> None:
+        # Import has to be here (or in each method needing iface),
+        # because iface is not automatically injected
+        # since this module is imported in conftest
+        from qgis.utils import iface
+
+        self._iface = iface
+
+    def create_feature_with_attribute_dialog(
+        self,
+        layer: QgsVectorLayer,
+        geometry: QgsGeometry,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> QgsFeature:
+        """
+        Create test feature with default values using QgsAttributeDialog.
+        This ensures that all the default values are honored and
+        for example boolean fields are either true or false, not null.
+        """
+        initial_ids = set(layer.allFeatureIds())
+
+        capabilities = layer.dataProvider().capabilities()
+
+        if not capabilities & QgsVectorDataProvider.AddFeatures:
+            raise ValueError(f"Could not create feature for the layer {layer.name()}")
+
+        new_feature = QgsVectorLayerUtils.createFeature(
+            layer, context=layer.createExpressionContext()
+        )
+        new_feature.setGeometry(geometry)
+
+        if attributes is not None:
+            if capabilities & QgsVectorDataProvider.ChangeAttributeValues:
+                for field_name, value in attributes.items():
+                    new_feature[field_name] = value
+            else:
+                raise ValueError(
+                    f"Could not change attributes for layer {layer.name()}"
+                )
+
+        assert new_feature.isValid()
+
+        context = QgsAttributeEditorContext()
+        context.setMapCanvas(self._iface.mapCanvas())
+
+        dialog = QgsAttributeDialog(
+            layer, new_feature, False, self._iface.mainWindow(), True, context
+        )
+        dialog.setMode(QgsAttributeEditorContext.AddFeatureMode)
+
+        # Two accepts to bypass some warnings
+        dialog.accept()
+        dialog.accept()
+        layer.commitChanges()
+
+        feature_ids = set(layer.allFeatureIds())
+        feature_id = list(feature_ids.difference(initial_ids))
+
+        assert feature_id, "Creating new feature failed"
+        return layer.getFeature(feature_id[0])

--- a/src/pytest_qgis/qgis_bot.py
+++ b/src/pytest_qgis/qgis_bot.py
@@ -25,7 +25,7 @@ from qgis.core import (
     QgsVectorLayer,
     QgsVectorLayerUtils,
 )
-from qgis.gui import QgsAttributeDialog, QgsAttributeEditorContext
+from qgis.gui import QgisInterface, QgsAttributeDialog, QgsAttributeEditorContext
 from qgis.PyQt.QtWidgets import QLabel, QWidget
 
 
@@ -34,11 +34,11 @@ class QgisBot:
     Class to hold common utility methods for interacting with QIGS.
     """
 
-    def __init__(self) -> None:
-        # Import has to be here (or in each method needing iface),
-        # because iface is not automatically injected
-        # since this module is imported in conftest
-        from qgis.utils import iface
+    def __init__(  # noqa: QGS105 # Iface has to be passed in order to
+        # ensure compatibility with all QGIS versions >= 3.10
+        self,
+        iface: QgisInterface,
+    ) -> None:
 
         self._iface = iface
 

--- a/src/pytest_qgis/utils.py
+++ b/src/pytest_qgis/utils.py
@@ -19,7 +19,7 @@
 from collections import Counter
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, List, Optional
 
 import sip
 from osgeo import gdal
@@ -35,8 +35,6 @@ from qgis.core import (
     QgsRectangle,
     QgsVectorLayer,
 )
-from qgis.gui import QgsAttributeDialog
-from qgis.PyQt.QtWidgets import QLabel, QWidget
 
 DEFAULT_RASTER_FORMAT = "tif"
 
@@ -172,30 +170,6 @@ def copy_layer_style_and_position(
     ]
 
     group.insertLayer(index + 1, layer2)
-
-
-def get_qgs_attribute_dialog_widgets_by_name(
-    widget: Union[QgsAttributeDialog, QWidget]
-) -> Dict[str, QWidget]:
-    """
-    Gets recursively all attribute dialog widgets by name.
-    :param widget: QgsAttributeDialog for the first time, afterwards QWidget.
-    :return: Dictionary with field names as keys and corresponding QWidgets as values.
-    """
-    widgets_by_name = {}
-    for child in widget.children():
-        if isinstance(child, QLabel):
-            if child.text() != "" and child.toolTip() != "":
-                related_widget = child.buddy()
-                if related_widget is not None:
-                    widgets_by_name[child.text()] = child.buddy()
-        if hasattr(child, "children"):
-            widgets_by_name = {
-                **widgets_by_name,
-                **get_qgs_attribute_dialog_widgets_by_name(child),
-            }
-
-    return widgets_by_name
 
 
 def clean_qgis_layer(fn: Callable) -> Callable:

--- a/tests/test_qgis_bot.py
+++ b/tests/test_qgis_bot.py
@@ -17,6 +17,7 @@
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 #
 from qgis.core import QgsGeometry
+from qgis.gui import QgsAttributeDialog
 
 
 def test_create_feature_with_attribute_dialog(layer_points, qgis_bot):
@@ -29,3 +30,24 @@ def test_create_feature_with_attribute_dialog(layer_points, qgis_bot):
     )
     assert layer.featureCount() == count + 1
     assert feat["bool_field"] is False  # With normal way of creating, it would be NULL.
+
+
+def test_get_qgs_attribute_dialog_widgets_by_name(qgis_iface, layer_points, qgis_bot):
+    dialog = QgsAttributeDialog(
+        layer_points,
+        layer_points.getFeature(1),
+        False,
+        qgis_iface.mainWindow(),
+        True,
+    )
+    widgets_by_name = qgis_bot.get_qgs_attribute_dialog_widgets_by_name(dialog)
+    assert {
+        name: widget.__class__.__name__ for name, widget in widgets_by_name.items()
+    } == {
+        "bool_field": "QCheckBox",
+        "date_field": "QDateTimeEdit",
+        "datetime_field": "QDateTimeEdit",
+        "decimal_field": "QgsFilterLineEdit",
+        "fid": "QgsFilterLineEdit",
+        "text_field": "QgsFilterLineEdit",
+    }

--- a/tests/test_qgis_bot.py
+++ b/tests/test_qgis_bot.py
@@ -16,16 +16,19 @@
 #  You should have received a copy of the GNU General Public License
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 #
+import pytest
 from qgis.core import QgsGeometry
 from qgis.gui import QgsAttributeDialog
 
 
-def test_create_feature_with_attribute_dialog(layer_points, qgis_bot):
+@pytest.mark.parametrize("bot", ["qgis_bot", "module_qgis_bot"])
+def test_create_feature_with_attribute_dialog(layer_points, bot, request):
+    bot = request.getfixturevalue(bot)
     layer = layer_points
     count = layer.featureCount()
 
     layer.startEditing()
-    feat = qgis_bot.create_feature_with_attribute_dialog(
+    feat = bot.create_feature_with_attribute_dialog(
         layer, QgsGeometry.fromWkt("POINT(0,0)")
     )
     assert layer.featureCount() == count + 1

--- a/tests/test_qgis_bot.py
+++ b/tests/test_qgis_bot.py
@@ -1,0 +1,31 @@
+#  Copyright (C) 2021-2022 pytest-qgis Contributors.
+#
+#
+#  This file is part of pytest-qgis.
+#
+#  pytest-qgis is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  pytest-qgis is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
+#
+from qgis.core import QgsGeometry
+
+
+def test_create_feature_with_attribute_dialog(layer_points, qgis_bot):
+    layer = layer_points
+    count = layer.featureCount()
+
+    layer.startEditing()
+    feat = qgis_bot.create_feature_with_attribute_dialog(
+        layer, QgsGeometry.fromWkt("POINT(0,0)")
+    )
+    assert layer.featureCount() == count + 1
+    assert feat["bool_field"] is False  # With normal way of creating, it would be NULL.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,13 +19,11 @@
 import pytest
 import sip
 from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsVectorLayer
-from qgis.gui import QgsAttributeDialog
 
 from pytest_qgis.utils import (
     clean_qgis_layer,
     get_common_extent_from_all_layers,
     get_layers_with_different_crs,
-    get_qgs_attribute_dialog_widgets_by_name,
     replace_layers_with_reprojected_clones,
     set_map_crs_based_on_layers,
 )
@@ -116,24 +114,3 @@ def test_clean_qgis_layer(layer_polygon):
     list(layer_function())
 
     assert sip.isdeleted(layer)
-
-
-def test_get_qgs_attribute_dialog_widgets_by_name(qgis_iface, layer_points):
-    dialog = QgsAttributeDialog(
-        layer_points,
-        layer_points.getFeature(1),
-        False,
-        qgis_iface.mainWindow(),
-        True,
-    )
-    widgets_by_name = get_qgs_attribute_dialog_widgets_by_name(dialog)
-    assert {
-        name: widget.__class__.__name__ for name, widget in widgets_by_name.items()
-    } == {
-        "bool_field": "QCheckBox",
-        "date_field": "QDateTimeEdit",
-        "datetime_field": "QDateTimeEdit",
-        "decimal_field": "QgsFilterLineEdit",
-        "fid": "QgsFilterLineEdit",
-        "text_field": "QgsFilterLineEdit",
-    }

--- a/tests/visual/test_qgis_ui.py
+++ b/tests/visual/test_qgis_ui.py
@@ -21,14 +21,14 @@ from qgis.gui import QgsAttributeDialog
 from qgis.PyQt import QtCore
 from qgis.PyQt.QtCore import QCoreApplication
 
-from pytest_qgis.utils import get_qgs_attribute_dialog_widgets_by_name
-
 from ..utils import IN_CI
 
 TIMEOUT = 0.01 if IN_CI else 1
 
 
-def test_attribute_dialog_change(qgis_iface, qgis_canvas, layer_points, qtbot):
+def test_attribute_dialog_change(
+    qgis_iface, qgis_canvas, layer_points, qgis_bot, qtbot
+):
     # The essential thing is QgsGui.editorWidgetRegistry().initEditors()
     layer = layer_points
 
@@ -46,7 +46,7 @@ def test_attribute_dialog_change(qgis_iface, qgis_canvas, layer_points, qtbot):
     qtbot.add_widget(dialog)
     dialog.show()
 
-    widgets_by_name = get_qgs_attribute_dialog_widgets_by_name(dialog)
+    widgets_by_name = qgis_bot.get_qgs_attribute_dialog_widgets_by_name(dialog)
     test_text = "New string"
 
     # Doubleclick and keys after that erase the old text


### PR DESCRIPTION
This PR:
- Adds `QgisBot` as `qgis_bot` and `module_qgis_bot` fixtures.
- Adds utility method `QgisBot.create_feature_with_attribute_dialog` to create features safely with default values. This makes creating features closer to what it really is using GUI.
- Moves `get_qgs_attribute_dialog_widgets_by_name` to be part of `QgisBot`