### PR TITLE
Added a newProjectCreated signal to QgisInterface mock class

### DIFF
--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -37,6 +37,7 @@ from qgis.gui import QgsGui, QgsLayerTreeMapCanvasBridge, QgsMapCanvas
 from qgis.PyQt import QtCore, QtWidgets
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QMessageBox, QWidget
+from qgis.PyQt.QtWidgets import QMainWindow
 
 from pytest_qgis.mock_qgis_classes import MockMessageBar
 from pytest_qgis.qgis_interface import QgisInterface
@@ -272,7 +273,7 @@ def _start_and_configure_qgis_app(config: "Config") -> None:
         _APP = QgsApplication([], GUIenabled=settings.gui_enabled)
         _APP.initQgis()
         QgsGui.editorWidgetRegistry().initEditors()
-    _PARENT = QWidget()
+    _PARENT = QMainWindow()
     _CANVAS = QgsMapCanvas(_PARENT)
     _CANVAS.resize(QtCore.QSize(settings.canvas_width, settings.canvas_height))
 

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -36,8 +36,7 @@ from qgis.gui import QgisInterface as QgisInterfaceOrig
 from qgis.gui import QgsGui, QgsLayerTreeMapCanvasBridge, QgsMapCanvas
 from qgis.PyQt import QtCore, QtWidgets
 from qgis.PyQt.QtCore import QCoreApplication
-from qgis.PyQt.QtWidgets import QMessageBox, QWidget
-from qgis.PyQt.QtWidgets import QMainWindow
+from qgis.PyQt.QtWidgets import QMainWindow, QMessageBox, QWidget
 
 from pytest_qgis.mock_qgis_classes import MockMessageBar
 from pytest_qgis.qgis_interface import QgisInterface

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -42,6 +42,7 @@ from qgis.PyQt.QtCore import QObject, pyqtSignal, pyqtSlot
 from qgis.PyQt.QtWidgets import QAction, QDockWidget, QWidget
 from qgis.PyQt.QtWidgets import QMainWindow
 from qgis.PyQt.QtWidgets import QMenuBar
+from qgis.PyQt.QtWidgets import QToolBar
 from pytest_qgis.mock_qgis_classes import MockMessageBar
 
 LOGGER = logging.getLogger("QGIS")
@@ -84,6 +85,9 @@ class QgisInterface(QObject):
         # Add the MenuBar
         menu_bar = QMenuBar()
         self._mainWindow.setMenuBar(menu_bar)
+
+        # Add the toolbar list
+        self._toolbars = list()
 
     @pyqtSlot("QList<QgsMapLayer*>")
     def addLayers(self, layers: List[QgsMapLayer]) -> None:
@@ -209,13 +213,15 @@ class QgisInterface(QObject):
         """
         pass
 
-    def addToolBar(self, name: str) -> None:
+    def addToolBar(self, name: str) -> QToolBar:
         """Add toolbar with specified name.
 
         :param name: Name for the toolbar.
         :type name: str
         """
-        pass
+        toolbar = QToolBar(self._mainWindow)
+        self._toolbars.append(toolbar)
+        return toolbar
 
     def mapCanvas(self) -> QgsMapCanvas:
         """Return a pointer to the map canvas."""

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -27,7 +27,7 @@ __copyright__ = (
 )
 
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import sip
 from qgis.core import (
@@ -39,10 +39,15 @@ from qgis.core import (
 )
 from qgis.gui import QgsMapCanvas
 from qgis.PyQt.QtCore import QObject, pyqtSignal, pyqtSlot
-from qgis.PyQt.QtWidgets import QAction, QDockWidget, QWidget
-from qgis.PyQt.QtWidgets import QMainWindow
-from qgis.PyQt.QtWidgets import QMenuBar
-from qgis.PyQt.QtWidgets import QToolBar
+from qgis.PyQt.QtWidgets import (
+    QAction,
+    QDockWidget,
+    QMainWindow,
+    QMenuBar,
+    QToolBar,
+    QWidget,
+)
+
 from pytest_qgis.mock_qgis_classes import MockMessageBar
 
 LOGGER = logging.getLogger("QGIS")

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -62,6 +62,7 @@ class QgisInterface(QObject):
     """
 
     currentLayerChanged = pyqtSignal(QgsMapCanvas)  # noqa N802
+    newProjectCreated = pyqtSignal()  # noqa N802
 
     def __init__(
         self, canvas: QgsMapCanvas, messageBar: MockMessageBar, mainWindow: QMainWindow
@@ -135,6 +136,7 @@ class QgisInterface(QObject):
         for relation in relation_manager.relations():
             relation_manager.removeRelation(relation)
         self._layers = []
+        self.newProjectCreated.emit()
 
     # ---------------- API Mock for QgsInterface follows -------------------
 

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -87,7 +87,7 @@ class QgisInterface(QObject):
         self._mainWindow.setMenuBar(menu_bar)
 
         # Add the toolbar list
-        self._toolbars = list()
+        self._toolbars: Dict[str, QToolBar] = {}
 
     @pyqtSlot("QList<QgsMapLayer*>")
     def addLayers(self, layers: List[QgsMapLayer]) -> None:

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -219,7 +219,7 @@ class QgisInterface(QObject):
         :param name: Name for the toolbar.
         :type name: str
         """
-        toolbar = QToolBar(self._mainWindow)
+        toolbar = QToolBar(name, parent=self._mainWindow)
         self._toolbars.append(toolbar)
         return toolbar
 

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -40,7 +40,8 @@ from qgis.core import (
 from qgis.gui import QgsMapCanvas
 from qgis.PyQt.QtCore import QObject, pyqtSignal, pyqtSlot
 from qgis.PyQt.QtWidgets import QAction, QDockWidget, QWidget
-
+from qgis.PyQt.QtWidgets import QMainWindow
+from qgis.PyQt.QtWidgets import QMenuBar
 from pytest_qgis.mock_qgis_classes import MockMessageBar
 
 LOGGER = logging.getLogger("QGIS")
@@ -57,7 +58,7 @@ class QgisInterface(QObject):
     currentLayerChanged = pyqtSignal(QgsMapCanvas)  # noqa N802
 
     def __init__(
-        self, canvas: QgsMapCanvas, messageBar: MockMessageBar, mainWindow: QWidget
+        self, canvas: QgsMapCanvas, messageBar: MockMessageBar, mainWindow: QMainWindow
     ) -> None:
         """Constructor
         :param canvas:
@@ -79,6 +80,10 @@ class QgisInterface(QObject):
         # For processing module
         self.destCrs = None
         self._layers: List[QgsMapLayer] = []
+
+        # Add the MenuBar
+        menu_bar = QMenuBar()
+        self._mainWindow.setMenuBar(menu_bar)
 
     @pyqtSlot("QList<QgsMapLayer*>")
     def addLayers(self, layers: List[QgsMapLayer]) -> None:

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -220,7 +220,7 @@ class QgisInterface(QObject):
         :type name: str
         """
         toolbar = QToolBar(name, parent=self._mainWindow)
-        self._toolbars.append(toolbar)
+        self._toolbars[name] = toolbar
         return toolbar
 
     def mapCanvas(self) -> QgsMapCanvas:


### PR DESCRIPTION
The QgisInterface mock class lacks of a new project signal, so the signal is created and when the newProject method is called the signal is emitted to connected slots.
Again, as a Newby in these issues, my previous commits of a previous accepted PR appear. I don't know why. Fortunately it says 1 file changed, so I'm creating the PR.