### PR TITLE
Support QToolBar in iface.addToolBar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Run tests
         run: >
           docker run --rm --net=host -e QGIS_IN_CI=1 --volume `pwd`:/app -w=/app qgis/qgis:${{ matrix.docker_tags }} sh -c
-          "pip3 install -qr requirements.txt pytest-cov pytest-qt==3.3.0 && pip3 install -e . && xvfb-run -s '+extension GLX -screen 0 1024x768x24'
-          pytest -v --cov src/pytest_qgis --cov-report=xml"
+          "pip3 install -qr requirements.txt pytest-cov && pip3 install -e . && xvfb-run -s '+extension GLX -screen 0 1024x768x24'
+          pytest -v --cov src/pytest_qgis --cov-report=xml -m 'not with_pytest_qt' -p no:pytest-qt"
 
       # Upload coverage report. Will not work if the repo is private
       - name: Upload coverage to Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,8 @@ repos:
         rev: 21.5b1
         hooks:
         -   id: black
+            additional_dependencies:
+                - click==8.0.4
     - repo: https://github.com/PyCQA/flake8
       rev: 3.9.2
       hooks:

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -27,7 +27,7 @@ __copyright__ = (
 )
 
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import sip
 from qgis.core import (
@@ -220,15 +220,19 @@ class QgisInterface(QObject):
         """
         pass
 
-    def addToolBar(self, name: str) -> QToolBar:
+    def addToolBar(self, toolbar: Union[str, QToolBar]) -> QToolBar:
         """Add toolbar with specified name.
 
-        :param name: Name for the toolbar.
-        :type name: str
+        :param toolbar: Name for the toolbar or QToolBar object.
         """
-        toolbar = QToolBar(name, parent=self._mainWindow)
-        self._toolbars[name] = toolbar
-        return toolbar
+        if isinstance(toolbar, str):
+            name = toolbar
+            _toolbar = QToolBar(name, parent=self._mainWindow)
+        else:
+            name = toolbar.windowTitle()
+            _toolbar = toolbar
+        self._toolbars[name] = _toolbar
+        return _toolbar
 
     def mapCanvas(self) -> QgsMapCanvas:
         """Return a pointer to the map canvas."""

--- a/tests/test_pytest_qgis.py
+++ b/tests/test_pytest_qgis.py
@@ -106,8 +106,16 @@ def test_iface_active_layer(qgis_iface, layer_polygon, layer_points):
     assert qgis_iface.activeLayer() == layer_points
 
 
-def test_iface_toolbar(qgis_iface):
+def test_iface_toolbar_str(qgis_iface):
     name = "test_bar"
     toolbar: QToolBar = qgis_iface.addToolBar(name)
+    assert toolbar.windowTitle() == name
+    assert qgis_iface._toolbars == {name: toolbar}
+
+
+def test_iface_toolbar_qtoolbar(qgis_iface):
+    name = "test_bar"
+    toolbar: QToolBar = QToolBar(name)
+    qgis_iface.addToolBar(toolbar)
     assert toolbar.windowTitle() == name
     assert qgis_iface._toolbars == {name: toolbar}

--- a/tests/visual/test_qgis_ui.py
+++ b/tests/visual/test_qgis_ui.py
@@ -17,6 +17,7 @@
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 import time
 
+import pytest
 from qgis.gui import QgsAttributeDialog
 from qgis.PyQt import QtCore
 from qgis.PyQt.QtCore import QCoreApplication
@@ -26,6 +27,7 @@ from ..utils import IN_CI
 TIMEOUT = 0.01 if IN_CI else 1
 
 
+@pytest.mark.with_pytest_qt()
 def test_attribute_dialog_change(
     qgis_iface, qgis_canvas, layer_points, qgis_bot, qtbot
 ):

--- a/tests/visual/test_show_map.py
+++ b/tests/visual/test_show_map.py
@@ -23,6 +23,11 @@ from ..utils import IN_CI, QGIS_VERSION
 
 """
 These tests are meant to be tested visually by the developer.
+
+NOTE: if you have pytest-qt installed, you might encounter some
+problems with tests in this module.
+
+In that case, run these tests with pytest-qt disabled: "pytest -p no:pytest-qt"
 """
 
 DEFAULT_TIMEOUT = 0.01 if IN_CI else 1


### PR DESCRIPTION
This PR:
- Adds possibility to use `QToolBar` as an argument in `iface.addToolBar` method
- Fixes pre-commit environment

Fixes #19.