### PR TITLE
Use tempfile instead of protected TempPathFactory in QGIS config path creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ markers can be used.
   to ensure that they are cleaned properly if they are used but not added to the `QgsProject`. This is only needed with
   layers with other than memory provider.
    ```python
-   # conftest.py of start of a test file
+   # conftest.py or start of a test file
    import pytest
    from pytest_qgis.utils import clean_qgis_layer
    from qgis.core import QgsVectorLayer
@@ -74,11 +74,13 @@ markers can be used.
   configure [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html). With QGIS >= 3.18 it is also
   used to patch `qgis.utils.iface` with `qgis_iface` automatically.
 
+  > Be careful not to import modules importing `qgis.utils.iface` in the root of conftest, because the `pytest_configure` hook has not yet patched `iface` in that point. See [this issue](https://github.com/GispoCoding/pytest-qgis/issues/35) for details.
+
 ### Command line options
 
 * `--qgis_disable_gui` can be used to disable graphical user interface in tests. This speeds up the tests that use Qt
   widgets of the plugin.
-* `--qgis_disable_init` can be used to prevent QGIS (QgsApllication) from initializing. Mainly used in internal testing.
+* `--qgis_disable_init` can be used to prevent QGIS (QgsApplication) from initializing. Mainly used in internal testing.
 
 ### ini-options
 


### PR DESCRIPTION
When using pytest-qgis with pytest-xdist plugin on Windows, the following errors occur: 
```shell
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: '\\\\?\\C:\\Users\\foo\\AppData\\Local\\Temp\\pytest-of-foo\\pytest-177\\popen-gw0\\qgis-test0\
\profiles\\default\\qgis-auth.db'
```
This is caused by creating temporary path for QGIS using pytest's internal `TempPathFactory`, which is not ment to be used by the plugins or in hooks... 

This PR suggests a change to use `tempfile` module instead of `TempPathFactory` in QGIS config path creation. This is to allow using pytest-xdist plugin to run tests in parallel. In addition plugin pytest-rerunfailures can be used to rerun tests failing randomly with segmentation faults.

This PR also adds a mention about importing modules in conftest to resolve #35.