### PR TITLE
Improve showing map

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ This plugin makes it easier to write QGIS plugin tests with the help of some fix
 
 ### Markers
 
-* `qgis_show_map` lets developer inspect the QGIS map visually at the teardown of the test. Full signature of the marker
+* `qgis_show_map` lets developer inspect the QGIS map visually during the test and also at the teardown of the test. Full signature of the marker
   is:
   ```python
   @pytest.mark.qgis_show_map(timeout: int = 30, add_basemap: bool = False, zoom_to_common_extent: bool = True, extent: QgsRectangle = None)
   ```
-    * `timeout` is the time in seconds until the map is closed.
+    * `timeout` is the time in seconds until the map is closed. If timeout is zero, the map will be closed in teardown.
     * `add_basemap` when set to True, adds Natural Earth countries layer as the basemap for the map.
     * `zoom_to_common_extent` when set to True, centers the map around all layers in the project.
     * `extent` is alternative to `zoom_to_common_extent` and lets user specify the extent

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -325,19 +325,19 @@ def _initialize_processing(qgis_app: QgsApplication) -> None:
 
 
 def _show_qgis_dlg(common_settings: Settings, qgis_parent: QWidget) -> None:
-    if common_settings.gui_enabled and not common_settings.qgis_init_disabled:
+    if not common_settings.qgis_init_disabled:
         qgis_parent.setWindowTitle("Test QGIS dialog opened by Pytest-qgis")
         qgis_parent.show()
-    elif not common_settings.gui_enabled:
-        warnings.warn(
-            "Cannot show QGIS map because the GUI is not enabled. "
-            "Set qgis_qui_enabled=True in pytest.ini.",
-            stacklevel=1,
-        )
     elif common_settings.qgis_init_disabled:
         warnings.warn(
             "Cannot show QGIS map because QGIS is not initialized. "
             "Run the tests without --qgis_disable_init to enable QGIS map.",
+            stacklevel=1,
+        )
+    if not common_settings.gui_enabled:
+        warnings.warn(
+            "QGIS map is not visible because the GUI is not enabled. "
+            "Set qgis_qui_enabled=True in pytest.ini to see the window.",
             stacklevel=1,
         )
 

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -264,6 +264,10 @@ def qgis_show_map(
     common_settings: Settings = request.config._plugin_settings  # type: ignore
 
     if show_map_marker:
+        # Assign the bridge to have correct layer order and visibilities
+        bridge = QgsLayerTreeMapCanvasBridge(  # noqa: F841, this needs to be assigned
+            QgsProject.instance().layerTreeRoot(), qgis_iface.mapCanvas()
+        )
         _show_qgis_dlg(common_settings, qgis_parent)
 
     yield
@@ -346,9 +350,7 @@ def _configure_qgis_map(
     tmp_path: Path,
 ) -> None:
     message_box = QMessageBox(qgis_parent)
-    bridge = QgsLayerTreeMapCanvasBridge(  # noqa: F841, this needs to be assigned
-        QgsProject.instance().layerTreeRoot(), qgis_iface.mapCanvas()
-    )
+
     try:
         # Change project CRS to most common CRS if it is not set
         if not QgsProject.instance().crs().isValid():

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -390,10 +390,7 @@ def _configure_qgis_map(
             f"It will close automatically in {settings.timeout} seconds."
         )
         message_box.addButton(QMessageBox.Close)
-        message_box.move(
-            message_box.mapToGlobal(qgis_parent.rect().topLeft())
-            - QtCore.QPoint(message_box.width(), 0)
-        )
+        message_box.move(QgsApplication.instance().primaryScreen().geometry().topLeft())
         message_box.setWindowModality(QtCore.Qt.NonModal)
         message_box.show()
 

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -300,6 +300,7 @@ def _start_and_configure_qgis_app(config: "Config") -> None:
         QgsGui.editorWidgetRegistry().initEditors()
     _PARENT = QMainWindow()
     _CANVAS = QgsMapCanvas(_PARENT)
+    _PARENT.resize(QtCore.QSize(settings.canvas_width, settings.canvas_height))
     _CANVAS.resize(QtCore.QSize(settings.canvas_width, settings.canvas_height))
 
     # QgisInterface is a stub implementation of the QGIS plugin interface

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -349,6 +349,10 @@ def _configure_qgis_map(
     settings: ShowMapSettings,
     tmp_path: Path,
 ) -> None:
+    if settings.timeout == 0:
+        qgis_parent.close()
+        return
+
     message_box = QMessageBox(qgis_parent)
 
     try:

--- a/tests/visual/test_show_map.py
+++ b/tests/visual/test_show_map.py
@@ -39,8 +39,9 @@ def setup(qgis_new_project):
 
 
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT)
-def test_show_map(layer_polygon):
+def test_show_map(layer_polygon, qgis_canvas, qgis_parent):
     QgsProject.instance().addMapLayers([layer_polygon])
+    assert qgis_parent.size() == qgis_canvas.size()
 
 
 @pytest.mark.qgis_show_map(timeout=0)

--- a/tests/visual/test_show_map.py
+++ b/tests/visual/test_show_map.py
@@ -43,6 +43,11 @@ def test_show_map(layer_polygon):
     QgsProject.instance().addMapLayers([layer_polygon])
 
 
+@pytest.mark.qgis_show_map(timeout=0)
+def test_show_map_with_zero_timeout(layer_polygon):
+    QgsProject.instance().addMapLayers([layer_polygon])
+
+
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT, extent=QgsRectangle(25, 65, 26, 66))
 def test_show_map_custom_extent(layer_polygon):
     QgsProject.instance().addMapLayers([layer_polygon])


### PR DESCRIPTION
This PR  improves `qgis_show_map` marker by:
- Ensuring that all layers are in shown with correct order and visibility even before test teardown
- Not running extra code in teardown if timeout is set to zero
- Resizing the `qgis_parent` to match the canvas size
- Moving the message box window to proper top left corner
- Opening QGIS parent window even though GUI is disabled. This allows the tests that require the opened parent window to succeed even though the window is not visibel to user.

Resolves #38