### PR TITLE
Clean map layers automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,24 +50,6 @@ Check the marker api [documentation](https://docs.pytest.org/en/latest/mark.html
 and [examples](https://docs.pytest.org/en/latest/example/markers.html#marking-whole-classes-or-modules) for the ways
 markers can be used.
 
-### Utility tools
-
-* `clean_qgis_layer` decorator found in `pytest_qgis.utils` is a decorator which can be used with `QgsMapLayer` fixtures
-  to ensure that they are cleaned properly if they are used but not added to the `QgsProject`. This is only needed with
-  layers with other than memory provider.
-   ```python
-   # conftest.py or start of a test file
-   import pytest
-   from pytest_qgis.utils import clean_qgis_layer
-   from qgis.core import QgsVectorLayer
-
-   @pytest.fixture()
-   @clean_qgis_layer
-   def some_layer() -> QgsVectorLayer:
-     return QgsVectorLayer("layer_file.geojson", "some layer")
-
-   ```
-
 ### Hooks
 
 * `pytest_configure` hook is used to initialize and
@@ -75,6 +57,8 @@ markers can be used.
   used to patch `qgis.utils.iface` with `qgis_iface` automatically.
 
   > Be careful not to import modules importing `qgis.utils.iface` in the root of conftest, because the `pytest_configure` hook has not yet patched `iface` in that point. See [this issue](https://github.com/GispoCoding/pytest-qgis/issues/35) for details.
+
+* `pytest_runtest_teardown` hook is used to ensure that all layer fixtures of any scope are cleaned properly without causing segmentation faults. The layer fixtures that are cleaned automatically must have some of the following keywords in their name: "layer", "lyr", "raster", "rast", "tif".
 
 ### Command line options
 

--- a/src/pytest_qgis/utils.py
+++ b/src/pytest_qgis/utils.py
@@ -130,6 +130,9 @@ def replace_layers_with_reprojected_clones(
             "native:reprojectlayer",
             {"INPUT": input_layer, "TARGET_CRS": map_crs, "OUTPUT": "TEMPORARY_OUTPUT"},
         )["OUTPUT"]
+        if not output_layer.crs().isValid():
+            output_layer.setCrs(map_crs)
+
         copy_layer_style_and_position(input_layer, output_layer, output_path)
 
     for input_layer in raster_layers:
@@ -140,12 +143,14 @@ def replace_layers_with_reprojected_clones(
             warp = gdal.Warp(
                 output_raster, input_layer.source(), dstSRS=map_crs.authid()
             )
+
         finally:
             warp = None  # noqa: F841
 
-        copy_layer_style_and_position(
-            input_layer, QgsRasterLayer(output_raster), output_path
-        )
+        output_layer = QgsRasterLayer(output_raster)
+        if not output_layer.crs().isValid():
+            output_layer.setCrs(map_crs)
+        copy_layer_style_and_position(input_layer, output_layer, output_path)
 
     # Remove originals from project
     QgsProject.instance().removeMapLayers([layer.id() for layer in layers])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,33 +21,52 @@ from pathlib import Path
 import pytest
 from qgis.core import QgsRasterLayer, QgsVectorLayer
 
-from pytest_qgis.utils import clean_qgis_layer
-
 pytest_plugins = "pytester"
 
 
 @pytest.fixture()
 def gpkg(tmp_path: Path) -> Path:
-    db = Path(Path(__file__).parent, "data", "db.gpkg")
-    new_db_path = tmp_path / "db.gpkg"
-    shutil.copy(db, new_db_path)
-    return new_db_path
+    return get_copied_gpkg(tmp_path)
+
+
+@pytest.fixture(scope="module")
+def gpkg_module(tmpdir_factory) -> Path:
+    tmp_path = Path(tmpdir_factory.mktemp("pytest_qgis_data"))
+    return get_copied_gpkg(tmp_path)
+
+
+@pytest.fixture(scope="session")
+def gpkg_session(tmpdir_factory) -> Path:
+    tmp_path = Path(tmpdir_factory.mktemp("pytest_qgis_data"))
+    return get_copied_gpkg(tmp_path)
 
 
 @pytest.fixture()
-@clean_qgis_layer
 def layer_polygon(gpkg: Path):
     return get_gpkg_layer("polygon", gpkg)
 
 
 @pytest.fixture()
-@clean_qgis_layer
+def layer_polygon_function(gpkg: Path):
+    return get_gpkg_layer("polygon", gpkg)
+
+
+@pytest.fixture()
+def lyr_polygon_module(gpkg_module: Path):
+    return get_gpkg_layer("polygon", gpkg_module)
+
+
+@pytest.fixture()
+def layer_polygon_session(gpkg_session: Path):
+    return get_gpkg_layer("polygon", gpkg_session)
+
+
+@pytest.fixture()
 def layer_polygon_3067(gpkg: Path):
     return get_gpkg_layer("polygon_3067", gpkg)
 
 
 @pytest.fixture()
-@clean_qgis_layer
 def raster_3067():
     return get_raster_layer(
         "small raster 3067", Path(Path(__file__).parent, "data", "small_raster.tif")
@@ -55,15 +74,22 @@ def raster_3067():
 
 
 @pytest.fixture()
-@clean_qgis_layer
 def layer_points(gpkg: Path):
     return get_gpkg_layer("points", gpkg)
+
+
+def get_copied_gpkg(tmp_path: Path) -> Path:
+    db = Path(Path(__file__).parent, "data", "db.gpkg")
+    new_db_path = tmp_path / "db.gpkg"
+    shutil.copy(db, new_db_path)
+    return new_db_path
 
 
 def get_gpkg_layer(name: str, gpkg: Path) -> QgsVectorLayer:
     layer = QgsVectorLayer(f"{str(gpkg)}|layername={name}", name, "ogr")
     layer.setProviderEncoding("utf-8")
     assert layer.isValid()
+    assert layer.crs()
     return layer
 
 

--- a/tests/test_layer_cleanup.py
+++ b/tests/test_layer_cleanup.py
@@ -1,0 +1,60 @@
+#  Copyright (C) 2021-2023 pytest-qgis Contributors.
+#
+#
+#  This file is part of pytest-qgis.
+#
+#  pytest-qgis is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  pytest-qgis is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
+
+from qgis.core import QgsMapLayer, QgsProject
+
+"""
+Tests in this module will cause Segmentation fault error if
+non-memory layer is not cleaned properly.
+
+Tests are not parametrized since the problem cannot be observed with
+parametrized tests.
+"""
+
+
+def test_layer_fixture_should_be_cleaned(layer_polygon_function):
+    _test(layer_polygon_function)
+
+
+def test_layer_fixture_should_be_cleaned_module(lyr_polygon_module):
+    _test(lyr_polygon_module)
+
+
+def test_layer_fixture_should_be_cleaned_2(layer_polygon_function):
+    _test(layer_polygon_function)
+
+
+def test_layer_fixture_should_be_cleaned_session(layer_polygon_session):
+    _test(layer_polygon_session)
+
+
+def test_layer_fixture_should_be_cleaned_module_2(lyr_polygon_module):
+    _test(lyr_polygon_module)
+
+
+def test_layer_fixture_should_be_cleaned_session_2(layer_polygon_session):
+    _test(layer_polygon_session)
+
+
+def test_raster_layer_fixture_should_be_cleaned(raster_3067):
+    _test(raster_3067)
+
+
+def _test(layer: QgsMapLayer) -> None:
+    # Check that the layer is not in the project
+    assert not QgsProject.instance().mapLayer(layer.id())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,7 @@
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
-from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsVectorLayer
+from qgis.core import QgsProject, QgsVectorLayer
 from qgis.PyQt import sip
 
 from pytest_qgis.utils import (
@@ -27,12 +27,7 @@ from pytest_qgis.utils import (
     replace_layers_with_reprojected_clones,
     set_map_crs_based_on_layers,
 )
-from tests.utils import QGIS_VERSION
-
-EPSG_4326 = "EPSG:4326"
-EPSG_3067 = "EPSG:3067"
-
-DEFAULT_CRS = QgsCoordinateReferenceSystem(EPSG_4326)
+from tests.utils import DEFAULT_CRS, EPSG_3067, EPSG_4326, QGIS_VERSION
 
 
 @pytest.fixture()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@
 #
 import os
 
-from qgis.core import Qgis
+from qgis.core import Qgis, QgsCoordinateReferenceSystem
 
 try:
     QGIS_VERSION = Qgis.versionInt()
@@ -26,3 +26,9 @@ except AttributeError:
     QGIS_VERSION = Qgis.QGIS_VERSION_INT
 
 IN_CI = os.environ.get("QGIS_IN_CI")
+
+EPSG_4326 = "EPSG:4326"
+EPSG_3067 = "EPSG:3067"
+
+DEFAULT_CRS = QgsCoordinateReferenceSystem(EPSG_4326)
+CRS_3067 = QgsCoordinateReferenceSystem(EPSG_3067)


### PR DESCRIPTION
This PR:
- Cleans map layers automatically using `pytest_runtest_teardown` hook.
- Adds deprecation warning to `clean_qgis_layer` decorator.
- Fixes some broken tests with missing crs

Fixes #25.