### PR TITLE
Use session scope in qgis_bot fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* [#46] Use session scope in qgis_bot fixture
+* [#45] Clean map layers automatically
 
 # Version 1.3.5 (30-06-2023)
 * [#34](https://github.com/GispoCoding/pytest-qgis/pull/34) Use tempfile instead of protected TempPathFactory in QGIS config path creation

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ This plugin makes it easier to write QGIS plugin tests with the help of some fix
 * `qgis_app` returns and eventually exits fully
   configured [`QgsApplication`](https://qgis.org/pyqgis/master/core/QgsApplication.html). This fixture is called
   automatically on the start of pytest session.
-* `qgis_bot` returns a [`QgisBot`](#qgisbot), which holds common utility methods for interacting with QGIS. Also
-  fixture `module_qgis_bot` in module scope is provided.
+* `qgis_bot` returns a [`QgisBot`](#qgisbot), which holds common utility methods for interacting with QGIS.
 * `qgis_canvas` returns [`QgsMapCanvas`](https://qgis.org/pyqgis/master/gui/QgsMapCanvas.html).
 * `qgis_parent` returns the QWidget used as parent of the `qgis_canvas`
 * `qgis_iface` returns stubbed [`QgsInterface`](https://qgis.org/pyqgis/master/gui/QgisInterface.html)

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -241,7 +241,7 @@ def qgis_countries_layer(qgis_world_map_geopackage: Path) -> QgsVectorLayer:
     return _get_countries_layer(qgis_world_map_geopackage)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def qgis_bot(qgis_iface: QgisInterface) -> QgisBot:
     """
     Object that holds common utility methods for interacting with QGIS.
@@ -254,6 +254,11 @@ def module_qgis_bot(qgis_iface: QgisInterface) -> QgisBot:
     """
     Object that holds common utility methods for interacting with QGIS.
     """
+    warnings.warn(
+        "module_qgis_bot fixture will be deprecated. " "Use qgis_bot instead.",
+        PendingDeprecationWarning,
+        stacklevel=2,
+    )
     return QgisBot(qgis_iface)
 
 


### PR DESCRIPTION
This PR:
- Turns qgis_bot into session scoped fixture since its only requirement is session scoped as well and it has no reason to have any other scope
- Deprecates module_qgis_bot since it has no purpose anymore