### PR TITLE
Change linting to use Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,14 +1,4 @@
 [flake8]
-max_line_length = 88
+select = QGS
 per-file-ignores =
     src/pytest_qgis/pytest_qgis.py:QGS105
-    src/pytest_qgis/qgis_interface.py:N802,N803
-    tests/*:ANN001,ANN201
-extend-ignore =
-            # whitespace before ':'
-            E203,
-            # Missing type annotation for self in method
-            ANN101,
-            # fixture '{name}' does not return anything, add leading underscore
-            PT004
-ban-relative-imports = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,27 @@
-# pre-commit run --all-files
 repos:
-    -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v4.4.0
-        hooks:
-        -   id: end-of-file-fixer
-        -   id: trailing-whitespace
-    -   repo: https://github.com/pre-commit/mirrors-mypy
-        rev: v1.3.0
-        hooks:
-        -   id: mypy
-            args: [--ignore-missing-imports]
-    - repo: https://github.com/PyCQA/isort
-      rev: 5.12.0
-      hooks:
-          - id: isort
-    -   repo: https://github.com/psf/black
-        rev: 23.3.0
-        hooks:
-        -   id: black
-            additional_dependencies:
-                - click==8.1.3
-    - repo: https://github.com/PyCQA/flake8
-      rev: 6.0.0
-      hooks:
-          - id: flake8
-            additional_dependencies:
-                - flake8-bugbear==23.5.9
-                - pep8-naming==0.13.3
-                - flake8-annotations==3.0.1
-                - flake8-qgis==1.0.0
-                - flake8-pytest-style==1.7.2
-                - flake8-print==5.0.0
-                - flake8-tidy-imports==4.9.0
-                - flake8-comprehensions==3.13.0
-                - flake8-simplify==0.20.0
-                - flake8-pie==0.16.0
-                - flake8-noqa==1.3.1
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.3.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.6
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix, --extend-fixable=F401]
+      # Run the formatter.
+      - id: ruff-format
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-qgis==1.0.0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig",
+        "ms-python.flake8",
+        "charliermarsh.ruff",
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "python.languageServer": "Pylance",
+    "flake8.importStrategy": "fromEnvironment",
+    "ruff.importStrategy": "fromEnvironment",
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "[python]": {
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports.ruff": true,
+            "source.fixAll": true
+        },
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,10 @@ select = [
     "UP",  # pyupgrade
 ]
 
-ignore = ["ANN101"]
+ignore = [
+    "ANN101", # Missing type annotation for `self` in method
+    "PT004"  # Fixture does not return anything, add leading underscore
+]
 
 unfixable = [
     "F401", # Unused imports
@@ -116,5 +119,10 @@ unfixable = [
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-"src/pytest_qgis/qgis_interface.py"=["N802","N803"]
-"tests/*"=["ANN001","ANN201"]
+"src/pytest_qgis/pytest_qgis.py"=["PLR2004"]  # TODO: Fix magic values. Remove this after.
+"src/pytest_qgis/qgis_interface.py" = ["N802", "N803"]
+"tests/*" = [
+    "ANN001",
+    "ANN201",
+    "ARG001", # TODO: Unused function argument. These are mostly pytest fixtures. Find a way to allow these in tests. Remove this after.
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,51 @@ disable_error_code = "misc"
 ignore_missing_imports = true
 follow_imports = "silent"
 show_column_numbers = true
+
+[tool.ruff]
+line-length = 88
+indent-width = 4
+
+target-version = "py37"
+
+external = ["QGS"]
+
+[tool.ruff.lint]
+select = [
+    "ANN", # flake8-annotations
+    "ARG", # flake8-unused-arguments
+    "B",   # flake8-bugbear
+    "C",   # flake8-comprehensions
+    "C90", # flake8, mccabe
+    "E",   # flake8, pycodestyle
+    "F",   # flake8, Pyflakes
+    "I",   # isort
+    "INP", # flake8-no-pep420
+    "N",   # pep8-naming
+    "PIE", # flake8-pie
+    "PGH", # pygrep-hooks
+    "PL",  # pylint
+    "PT",  # flake8-pytest-style
+    "RUF", # Ruff-specific rules
+    "SIM", # flake8-simplify
+    "T",   # flake8-print
+    "ICN", # flake8-import-conventions
+    "TCH", # flake8-type-checking
+    "TID", # flake8-tidy-imports
+    "W",   # flake8, pycodestyle
+    "UP",  # pyupgrade
+]
+
+ignore = ["ANN101"]
+
+unfixable = [
+    "F401", # Unused imports
+    "F841", # Unused variables
+]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.per-file-ignores]
+"src/pytest_qgis/qgis_interface.py"=["N802","N803"]
+"tests/*"=["ANN001","ANN201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ pytest_qgis = ["py.typed"]
 
 [tool.pytest.ini_options]
 doctest_encoding = "utf-8"
-
+markers = [
+    "with_pytest_qt: these tests require pytest-qt (deselect with '-m \"with_pytest_qt\"')"
+]
 
 [tool.isort]
 profile = "black"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,6 +6,9 @@
 pip-tools
 
 # testing
+pytest
+pytest-cov
+pytest-qt==3.3.0
 
 # for linting checks at commit time
 pre-commit

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,28 +1,17 @@
--c requirements.txt
+-r requirements.txt
+
 -e file:.
 
 # Managing dependencies
 pip-tools
 
 # testing
-pytest-cov
-pytest-qt==3.3.0
 
 # for linting checks at commit time
 pre-commit
+
 # for ide linting
+ruff
 flake8
-flake8-annotations
-flake8-bugbear
-flake8-comprehensions
-flake8-noqa
-flake8-pie
-flake8-print
-flake8-pytest-style
 flake8-qgis
-flake8-simplify
-flake8-tidy-imports
-black
 mypy
-isort
-pep8-naming

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -10,6 +10,9 @@ pytest
 pytest-cov
 pytest-qt==3.3.0
 
+# typing
+PyQt5-stubs
+
 # for linting checks at commit time
 pre-commit
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -83,6 +83,8 @@ pyflakes==3.1.0
     # via flake8
 pyproject-hooks==1.0.0
     # via build
+pyqt5-stubs==5.15.6.0
+    # via -r .\requirements-dev.in
 pytest==6.2.5
     # via
     #   -r .\requirements-dev.in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,39 +7,27 @@
 -e file:.
     # via -r .\requirements-dev.in
 astor==0.8.1
-    # via
-    #   flake8-qgis
-    #   flake8-simplify
+    # via flake8-qgis
 atomicwrites==1.4.1
     # via
-    #   -c .\requirements.txt
+    #   -r .\requirements.txt
     #   pytest
 attrs==23.1.0
     # via
-    #   -c .\requirements.txt
-    #   flake8-annotations
-    #   flake8-bugbear
+    #   -r .\requirements.txt
     #   pytest
-black==23.11.0
-    # via -r .\requirements-dev.in
 build==1.0.3
     # via pip-tools
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
-    # via
-    #   black
-    #   pip-tools
+    # via pip-tools
 colorama==0.4.6
     # via
-    #   -c .\requirements.txt
+    #   -r .\requirements.txt
     #   build
     #   click
     #   pytest
-coverage[toml]==7.3.2
-    # via
-    #   coverage
-    #   pytest-cov
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -47,36 +35,11 @@ filelock==3.13.1
 flake8==6.1.0
     # via
     #   -r .\requirements-dev.in
-    #   flake8-annotations
-    #   flake8-bugbear
-    #   flake8-comprehensions
     #   flake8-noqa
-    #   flake8-print
     #   flake8-qgis
-    #   flake8-simplify
-    #   flake8-tidy-imports
-    #   pep8-naming
-flake8-annotations==3.0.1
-    # via -r .\requirements-dev.in
-flake8-bugbear==23.11.26
-    # via -r .\requirements-dev.in
-flake8-comprehensions==3.14.0
-    # via -r .\requirements-dev.in
 flake8-noqa==1.3.2
     # via -r .\requirements-dev.in
-flake8-pie==0.16.0
-    # via -r .\requirements-dev.in
-flake8-plugin-utils==1.3.3
-    # via flake8-pytest-style
-flake8-print==5.0.0
-    # via -r .\requirements-dev.in
-flake8-pytest-style==1.7.2
-    # via -r .\requirements-dev.in
 flake8-qgis==1.0.0
-    # via -r .\requirements-dev.in
-flake8-simplify==0.21.0
-    # via -r .\requirements-dev.in
-flake8-tidy-imports==4.10.0
     # via -r .\requirements-dev.in
 identify==2.5.32
     # via pre-commit
@@ -84,83 +47,62 @@ importlib-metadata==6.8.0
     # via build
 iniconfig==2.0.0
     # via
-    #   -c .\requirements.txt
+    #   -r .\requirements.txt
     #   pytest
-isort==5.12.0
-    # via -r .\requirements-dev.in
 mccabe==0.7.0
     # via flake8
 mypy==1.7.1
     # via -r .\requirements-dev.in
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
+    # via mypy
 nodeenv==1.8.0
     # via pre-commit
 packaging==23.2
     # via
-    #   -c .\requirements.txt
-    #   black
+    #   -r .\requirements.txt
     #   build
     #   pytest
-pathspec==0.11.2
-    # via black
-pep8-naming==0.13.3
-    # via -r .\requirements-dev.in
 pip-tools==7.3.0
     # via -r .\requirements-dev.in
 platformdirs==4.0.0
-    # via
-    #   black
-    #   virtualenv
+    # via virtualenv
 pluggy==1.3.0
     # via
-    #   -c .\requirements.txt
+    #   -r .\requirements.txt
     #   pytest
 pre-commit==3.5.0
     # via -r .\requirements-dev.in
 py==1.11.0
     # via
-    #   -c .\requirements.txt
+    #   -r .\requirements.txt
     #   pytest
 pycodestyle==2.11.1
-    # via
-    #   flake8
-    #   flake8-print
+    # via flake8
 pyflakes==3.1.0
     # via flake8
 pyproject-hooks==1.0.0
     # via build
 pytest==6.2.5
     # via
-    #   -c .\requirements.txt
-    #   pytest-cov
+    #   -r .\requirements.txt
     #   pytest-qgis
-    #   pytest-qt
-pytest-cov==4.1.0
-    # via -r .\requirements-dev.in
-pytest-qt==3.3.0
-    # via -r .\requirements-dev.in
 pyyaml==6.0.1
     # via pre-commit
+ruff==0.1.6
+    # via -r .\requirements-dev.in
 toml==0.10.2
     # via
-    #   -c .\requirements.txt
+    #   -r .\requirements.txt
     #   pytest
 tomli==2.0.1
     # via
-    #   black
     #   build
-    #   coverage
     #   mypy
     #   pip-tools
     #   pyproject-hooks
 typing-extensions==4.8.0
     # via
-    #   black
     #   flake8-noqa
-    #   flake8-pie
     #   mypy
 virtualenv==20.24.7
     # via pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,6 +28,10 @@ colorama==0.4.6
     #   build
     #   click
     #   pytest
+coverage[toml]==7.3.2
+    # via
+    #   coverage
+    #   pytest-cov
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -35,10 +39,7 @@ filelock==3.13.1
 flake8==6.1.0
     # via
     #   -r .\requirements-dev.in
-    #   flake8-noqa
     #   flake8-qgis
-flake8-noqa==1.3.2
-    # via -r .\requirements-dev.in
 flake8-qgis==1.0.0
     # via -r .\requirements-dev.in
 identify==2.5.32
@@ -84,8 +85,15 @@ pyproject-hooks==1.0.0
     # via build
 pytest==6.2.5
     # via
+    #   -r .\requirements-dev.in
     #   -r .\requirements.txt
+    #   pytest-cov
     #   pytest-qgis
+    #   pytest-qt
+pytest-cov==4.1.0
+    # via -r .\requirements-dev.in
+pytest-qt==3.3.0
+    # via -r .\requirements-dev.in
 pyyaml==6.0.1
     # via pre-commit
 ruff==0.1.6
@@ -97,13 +105,12 @@ toml==0.10.2
 tomli==2.0.1
     # via
     #   build
+    #   coverage
     #   mypy
     #   pip-tools
     #   pyproject-hooks
 typing-extensions==4.8.0
-    # via
-    #   flake8-noqa
-    #   mypy
+    # via mypy
 virtualenv==20.24.7
     # via pre-commit
 wheel==0.42.0

--- a/src/pytest_qgis/__init__.py
+++ b/src/pytest_qgis/__init__.py
@@ -17,5 +17,5 @@
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from pytest_qgis._version import __version__  # noqa
-from pytest_qgis.pytest_qgis import *  # noqa
+from pytest_qgis._version import __version__  # noqa: F401
+from pytest_qgis.pytest_qgis import *  # noqa: F403

--- a/src/pytest_qgis/mock_qgis_classes.py
+++ b/src/pytest_qgis/mock_qgis_classes.py
@@ -40,7 +40,11 @@ class MockMessageBar(QObject):
         return self.messages[level]
 
     def pushMessage(  # noqa: N802
-        self, title: str, text: str, level: int, duration: int
+        self,
+        title: str,
+        text: str,
+        level: int,
+        duration: int,  # noqa: ARG002
     ) -> None:
         """A mocked method for pushing a message to the bar."""
         msg = f"{title}:{text}"

--- a/src/pytest_qgis/qgis_bot.py
+++ b/src/pytest_qgis/qgis_bot.py
@@ -44,7 +44,7 @@ class QgisBot:
     ) -> None:
         self._iface = iface
 
-    def create_feature_with_attribute_dialog(
+    def create_feature_with_attribute_dialog(  # noqa: PLR0913
         self,
         layer: QgsVectorLayer,
         geometry: QgsGeometry,

--- a/src/pytest_qgis/qgis_interface.py
+++ b/src/pytest_qgis/qgis_interface.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 """QGIS plugin implementation.
 
 .. note:: This program is free software; you can redistribute it and/or modify

--- a/src/pytest_qgis/utils.py
+++ b/src/pytest_qgis/utils.py
@@ -204,11 +204,11 @@ def ensure_qgis_layer_fixtures_are_cleaned(request: "FixtureRequest") -> None:
             _set_layer_owner_to_project(layer)
 
 
-def _set_layer_owner_to_project(layer: Any) -> None:
+def _set_layer_owner_to_project(layer: Any) -> None:  # noqa: ANN401
     if (
         isinstance(layer, QgsMapLayer)
         and not sip.isdeleted(layer)
-        and layer.id() not in QgsProject.instance().mapLayers(True).keys()
+        and layer.id() not in QgsProject.instance().mapLayers(True)
     ):
         QgsProject.instance().addMapLayer(layer)
         QgsProject.instance().removeMapLayer(layer)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def get_copied_gpkg(tmp_path: Path) -> Path:
 def get_gpkg_layer(
     name: str, gpkg: Path, crs: QgsCoordinateReferenceSystem = DEFAULT_CRS
 ) -> QgsVectorLayer:
-    layer = QgsVectorLayer(f"{str(gpkg)}|layername={name}", name, "ogr")
+    layer = QgsVectorLayer(f"{gpkg!s}|layername={name}", name, "ogr")
     layer.setProviderEncoding("utf-8")
     assert layer.isValid()
     if not layer.crs().isValid():

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    with_pytest_qt: these tests require pytest-qt (deselect with '-m "with_pytest_qt"')

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -16,8 +16,13 @@
 #  You should have received a copy of the GNU General Public License
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+from typing import TYPE_CHECKING
+
 import pytest
-from _pytest.pytester import Testdir
+
+if TYPE_CHECKING:
+    from _pytest.pytester import Testdir
 
 
 def test_ini_canvas(testdir: "Testdir"):

--- a/tests/test_pytest_qgis.py
+++ b/tests/test_pytest_qgis.py
@@ -15,7 +15,6 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
-from typing import TYPE_CHECKING
 
 import pytest
 from qgis.core import Qgis, QgsProcessing, QgsProject, QgsVectorLayer
@@ -24,8 +23,7 @@ from qgis.utils import iface
 
 from tests.utils import QGIS_VERSION
 
-if TYPE_CHECKING:
-    pass
+QGIS_3_18 = 31800
 
 # DO not use this directly, this is only meant to be used with
 # replace_iface_with_qgis_iface fixture
@@ -34,7 +32,7 @@ __iface = None
 
 @pytest.fixture()
 def replace_iface_with_qgis_iface(qgis_iface):
-    global __iface
+    global __iface  # noqa: PLW0603
     __iface = qgis_iface
 
 
@@ -88,7 +86,7 @@ def test_processing_run(qgis_processing):
 
 
 @pytest.mark.skipif(
-    QGIS_VERSION < 31800, reason="https://github.com/qgis/QGIS/issues/40564"
+    QGIS_VERSION < QGIS_3_18, reason="https://github.com/qgis/QGIS/issues/40564"
 )
 def test_setup_qgis_iface(qgis_iface):
     assert iface == qgis_iface

--- a/tests/test_qgis_bot.py
+++ b/tests/test_qgis_bot.py
@@ -23,10 +23,9 @@ from qgis.core import QgsFieldConstraints, QgsGeometry
 from qgis.gui import QgsAttributeDialog
 
 if TYPE_CHECKING:
+    from pytest_qgis.qgis_bot import QgisBot
     from qgis.core import QgsVectorLayer
     from qgis.gui import QgisInterface
-
-    from pytest_qgis.qgis_bot import QgisBot
 
 
 @pytest.fixture()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,15 +17,17 @@
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
-from qgis.core import QgsProject
-
 from pytest_qgis.utils import (
     get_common_extent_from_all_layers,
     get_layers_with_different_crs,
     replace_layers_with_reprojected_clones,
     set_map_crs_based_on_layers,
 )
+from qgis.core import QgsProject
+
 from tests.utils import DEFAULT_CRS, EPSG_3067, EPSG_4326, QGIS_VERSION
+
+QGIS_3_12 = 31200
 
 
 @pytest.fixture()
@@ -39,7 +41,8 @@ def layers_added(qgis_new_project, layer_polygon, layer_polygon_3067, raster_306
 
 
 @pytest.mark.skipif(
-    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+    QGIS_VERSION < QGIS_3_12,
+    reason="QGIS 3.10 test image cannot find correct algorithms",
 )
 def test_get_common_extent_from_all_layers(
     qgis_new_project, crs, layer_polygon, layer_polygon_3067
@@ -49,7 +52,8 @@ def test_get_common_extent_from_all_layers(
 
 
 @pytest.mark.skipif(
-    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+    QGIS_VERSION < QGIS_3_12,
+    reason="QGIS 3.10 test image cannot find correct algorithms",
 )
 def test_set_map_crs_based_on_layers_should_set_4326(qgis_new_project, layer_polygon):
     layer_polygon2 = layer_polygon.clone()
@@ -70,9 +74,10 @@ def test_get_layers_with_different_crs(
 
 
 @pytest.mark.skipif(
-    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+    QGIS_VERSION < QGIS_3_12,
+    reason="QGIS 3.10 test image cannot find correct algorithms",
 )
-def test_replace_layers_with_reprojected_clones(
+def test_replace_layers_with_reprojected_clones(  # noqa: PLR0913
     crs, layers_added, qgis_processing, layer_polygon_3067, raster_3067, tmp_path
 ):
     vector_layer_id = layer_polygon_3067.id()

--- a/tests/visual/test_show_map.py
+++ b/tests/visual/test_show_map.py
@@ -32,6 +32,9 @@ In that case, run these tests with pytest-qt disabled: "pytest -p no:pytest-qt"
 
 DEFAULT_TIMEOUT = 0.01 if IN_CI else 1
 
+QGIS_3_12 = 31200
+QGIS_3_18 = 31800
+
 
 @pytest.fixture(autouse=True)
 def setup(qgis_new_project):
@@ -61,58 +64,63 @@ def test_show_map_with_basemap(layer_polygon):
 
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT)
 @pytest.mark.skipif(
-    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+    QGIS_VERSION < QGIS_3_12,
+    reason="QGIS 3.10 test image cannot find correct algorithms",
 )
 def test_show_map_crs_change_to_3067(
     layer_polygon, layer_polygon_3067, raster_3067, qgis_version
 ):
     layer_polygon_3067.setOpacity(0.3)
-    if qgis_version > 31800:
+    if qgis_version > QGIS_3_18:
         raster_3067.setOpacity(0.9)
     QgsProject.instance().addMapLayers([layer_polygon, layer_polygon_3067, raster_3067])
 
 
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT)
 @pytest.mark.skipif(
-    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+    QGIS_VERSION < QGIS_3_12,
+    reason="QGIS 3.10 test image cannot find correct algorithms",
 )
 def test_show_map_crs_change_to_3067_with_different_layer_order(
     layer_polygon, layer_polygon_3067, raster_3067, qgis_version
 ):
     layer_polygon_3067.setOpacity(0.3)
-    if qgis_version > 31800:
+    if qgis_version > QGIS_3_18:
         raster_3067.setOpacity(0.9)
     QgsProject.instance().addMapLayers([raster_3067, layer_polygon_3067, layer_polygon])
 
 
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT, add_basemap=True)
 @pytest.mark.skipif(
-    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+    QGIS_VERSION < QGIS_3_12,
+    reason="QGIS 3.10 test image cannot find correct algorithms",
 )
 def test_show_map_crs_change_to_3067_with_basemap(
     layer_polygon, layer_polygon_3067, raster_3067, qgis_version
 ):
     layer_polygon_3067.setOpacity(0.3)
-    if qgis_version > 31800:
+    if qgis_version > QGIS_3_18:
         raster_3067.setOpacity(0.9)
     QgsProject.instance().addMapLayers([layer_polygon, layer_polygon_3067, raster_3067])
 
 
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT)
 @pytest.mark.skipif(
-    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+    QGIS_VERSION < QGIS_3_12,
+    reason="QGIS 3.10 test image cannot find correct algorithms",
 )
 def test_show_map_crs_change_to_4326(
     layer_polygon, raster_3067, layer_points, qgis_version
 ):
-    if qgis_version > 31800:
+    if qgis_version > QGIS_3_18:
         raster_3067.setOpacity(0.9)
     QgsProject.instance().addMapLayers([layer_points, layer_polygon, raster_3067])
 
 
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT)
 @pytest.mark.skipif(
-    QGIS_VERSION < 31200, reason="QGIS 3.10 test image cannot find correct algorithms"
+    QGIS_VERSION < QGIS_3_12,
+    reason="QGIS 3.10 test image cannot find correct algorithms",
 )
 def test_show_map_crs_change_to_4326_2(layer_polygon, layer_points, layer_polygon_3067):
     QgsProject.instance().addMapLayers(


### PR DESCRIPTION
Flake8 is still used for flake8-qgis checks.
Dropped flake8-noqa checks because it requred all other flake8 plugins to be installed.