### PR TITLE
Allow using MagicMocks to mock layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+* Allow using MagicMocks to mock layers without problems
+
 # Version 2.0.0 (29-11-2023)
 
 ## New Features

--- a/src/pytest_qgis/utils.py
+++ b/src/pytest_qgis/utils.py
@@ -19,7 +19,8 @@
 import time
 from collections import Counter
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
+from unittest.mock import MagicMock
 
 from osgeo import gdal
 from qgis.core import (
@@ -95,7 +96,7 @@ def transform_rectangle(
     return transform.transformBoundingBox(rectangle)
 
 
-def get_layers_with_different_crs() -> List[QgsMapLayer]:
+def get_layers_with_different_crs() -> list[QgsMapLayer]:
     map_crs = QgsProject.instance().crs()
     return [
         layer
@@ -105,7 +106,7 @@ def get_layers_with_different_crs() -> List[QgsMapLayer]:
 
 
 def replace_layers_with_reprojected_clones(
-    layers: List[QgsMapLayer], output_path: Path
+    layers: list[QgsMapLayer], output_path: Path
 ) -> None:
     """
     For some reason all layers having differing crs from the project are invisible.
@@ -207,6 +208,7 @@ def ensure_qgis_layer_fixtures_are_cleaned(request: "FixtureRequest") -> None:
 def _set_layer_owner_to_project(layer: Any) -> None:  # noqa: ANN401
     if (
         isinstance(layer, QgsMapLayer)
+        and not isinstance(layer, MagicMock)
         and not sip.isdeleted(layer)
         and layer.id() not in QgsProject.instance().mapLayers(True)
     ):

--- a/tests/test_layer_cleanup.py
+++ b/tests/test_layer_cleanup.py
@@ -15,8 +15,10 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
+from unittest.mock import MagicMock
 
-from qgis.core import QgsMapLayer, QgsProject
+import pytest
+from qgis.core import QgsMapLayer, QgsProject, QgsVectorLayer
 
 """
 Tests in this module will cause Segmentation fault error if
@@ -25,6 +27,14 @@ non-memory layer is not cleaned properly.
 Tests are not parametrized since the problem cannot be observed with
 parametrized tests.
 """
+
+
+@pytest.fixture()
+def stub_layer() -> MagicMock:
+    return MagicMock(
+        spec=QgsVectorLayer,
+        autospec=True,
+    )
 
 
 def test_layer_fixture_should_be_cleaned(layer_polygon_function):
@@ -58,3 +68,7 @@ def test_raster_layer_fixture_should_be_cleaned(raster_3067):
 def _test(layer: QgsMapLayer) -> None:
     # Check that the layer is not in the project
     assert not QgsProject.instance().mapLayer(layer.id())
+
+
+def test_mocked_layer_should_not_mess_with_cleaning_layers(stub_layer):
+    assert isinstance(stub_layer, QgsVectorLayer)


### PR DESCRIPTION
Fixes #53 by checking if the fixture type is `MagicMock`.