### PR TITLE
Do not use CRS operations before initializing QgsApplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
+      - name: Install venv
         run: |
-          python3 -m pip install -U pip setuptools
-          pip3 install -qr requirements.txt pytest-cov
-          pip3 install -e .
+          apt update
+          apt install -y python3-venv
+      - name: Create virtualenv and install dependencies
+        run: |
+          python3 -m venv --system-site-packages .venv
+          .venv/bin/pip install -U pip setuptools
+          .venv/bin/pip install -qr requirements.txt pytest-cov
+          .venv/bin/pip install -e .
       - name: Run tests
         env:
           QGIS_IN_CI: 1
         run: >
           xvfb-run -s '+extension GLX -screen 0 1024x768x24'
-          python3 -m pytest -v --cov src/pytest_qgis --cov-report=xml -m 'not with_pytest_qt' -p no:pytest-qt tests
+          .venv/bin/pytest -v --cov src/pytest_qgis --cov-report=xml -m 'not with_pytest_qt' -p no:pytest-qt tests
 
       # Upload coverage report. Will not work if the repo is private
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           QGIS_IN_CI: 1
         run: >
           xvfb-run -s '+extension GLX -screen 0 1024x768x24'
-          pytest -v --cov src/pytest_qgis --cov-report=xml -m 'not with_pytest_qt' -p no:pytest-qt tests
+          python3 -m pytest -v --cov src/pytest_qgis --cov-report=xml -m 'not with_pytest_qt' -p no:pytest-qt tests
 
       # Upload coverage report. Will not work if the repo is private
       - name: Upload coverage to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Fixes
 
-* Allow using MagicMocks to mock layers without problems
+* [#55](https://github.com/GispoCoding/pytest-qgis/pull/55) Allows using MagicMocks to mock layers without problems
+* [#60](https://github.com/GispoCoding/pytest-qgis/pull/60) Allows using CRS properly again
 
 # Version 2.0.0 (29-11-2023)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ ban-relative-imports = "all"
 [tool.ruff.per-file-ignores]
 "src/pytest_qgis/pytest_qgis.py"=["PLR2004"]  # TODO: Fix magic values. Remove this after.
 "src/pytest_qgis/qgis_interface.py" = ["N802", "N803"]
+"src/pytest_qgis/utils.py" = ["ANN401"]
 "tests/*" = [
     "ANN001",
     "ANN201",

--- a/src/pytest_qgis/utils.py
+++ b/src/pytest_qgis/utils.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 DEFAULT_RASTER_FORMAT = "tif"
 
-DEFAULT_CRS = QgsCoordinateReferenceSystem("EPSG:4326")
+DEFAULT_EPSG = "EPSG:4326"
 LAYER_KEYWORDS = ("layer", "lyr", "raster", "rast", "tif")
 
 
@@ -73,7 +73,7 @@ def set_map_crs_based_on_layers() -> None:
         crs_id, _ = crs_counter.most_common(1)[0]
         crs = QgsCoordinateReferenceSystem(crs_id)
     else:
-        crs = DEFAULT_CRS
+        crs = QgsCoordinateReferenceSystem(DEFAULT_EPSG)
     QgsProject.instance().setCrs(crs)
 
 
@@ -205,7 +205,7 @@ def ensure_qgis_layer_fixtures_are_cleaned(request: "FixtureRequest") -> None:
             _set_layer_owner_to_project(layer)
 
 
-def _set_layer_owner_to_project(layer: Any) -> None:  # noqa: ANN401
+def _set_layer_owner_to_project(layer: Any) -> None:
     if (
         isinstance(layer, QgsMapLayer)
         and not isinstance(layer, MagicMock)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,7 @@ import shutil
 from pathlib import Path
 
 import pytest
-from qgis.core import QgsCoordinateReferenceSystem, QgsRasterLayer, QgsVectorLayer
-
-from tests.utils import CRS_3067, DEFAULT_CRS
+from qgis.core import QgsRasterLayer, QgsVectorLayer
 
 pytest_plugins = "pytester"
 
@@ -65,7 +63,7 @@ def layer_polygon_session(gpkg_session: Path):
 
 @pytest.fixture()
 def layer_polygon_3067(gpkg: Path):
-    return get_gpkg_layer("polygon_3067", gpkg, CRS_3067)
+    return get_gpkg_layer("polygon_3067", gpkg)
 
 
 @pytest.fixture()
@@ -73,7 +71,6 @@ def raster_3067():
     return get_raster_layer(
         "small raster 3067",
         Path(Path(__file__).parent, "data", "small_raster.tif"),
-        CRS_3067,
     )
 
 
@@ -89,23 +86,15 @@ def get_copied_gpkg(tmp_path: Path) -> Path:
     return new_db_path
 
 
-def get_gpkg_layer(
-    name: str, gpkg: Path, crs: QgsCoordinateReferenceSystem = DEFAULT_CRS
-) -> QgsVectorLayer:
+def get_gpkg_layer(name: str, gpkg: Path) -> QgsVectorLayer:
     layer = QgsVectorLayer(f"{gpkg!s}|layername={name}", name, "ogr")
     layer.setProviderEncoding("utf-8")
     assert layer.isValid()
-    if not layer.crs().isValid():
-        layer.setCrs(crs)
     assert layer.crs().isValid()
     return layer
 
 
-def get_raster_layer(
-    name: str, path: Path, crs: QgsCoordinateReferenceSystem = DEFAULT_CRS
-) -> QgsRasterLayer:
+def get_raster_layer(name: str, path: Path) -> QgsRasterLayer:
     layer = QgsRasterLayer(str(path), name)
     assert layer.isValid()
-    if not layer.crs().isValid():
-        layer.setCrs(crs)
     return layer

--- a/tests/test_pytest_qgis.py
+++ b/tests/test_pytest_qgis.py
@@ -17,7 +17,13 @@
 #  along with pytest-qgis.  If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
-from qgis.core import Qgis, QgsProcessing, QgsProject, QgsVectorLayer
+from qgis.core import (
+    Qgis,
+    QgsCoordinateReferenceSystem,
+    QgsProcessing,
+    QgsProject,
+    QgsVectorLayer,
+)
 from qgis.PyQt.QtWidgets import QToolBar
 from qgis.utils import iface
 
@@ -127,3 +133,9 @@ def test_canvas_should_be_released(qgis_canvas, layer_polygon, layer_points):
     QgsProject.instance().addMapLayer(layer_polygon)
     QgsProject.instance().addMapLayer(layer_points)
     qgis_canvas.zoomToFullExtent()
+
+
+def test_crs_is_not_constructed_before_application():
+    wkt_4326 = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]'  # noqa: E501
+    crs = QgsCoordinateReferenceSystem.fromWkt(wkt_4326)
+    assert crs.isValid()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,16 +23,16 @@ from pytest_qgis.utils import (
     replace_layers_with_reprojected_clones,
     set_map_crs_based_on_layers,
 )
-from qgis.core import QgsProject
+from qgis.core import QgsCoordinateReferenceSystem, QgsProject
 
-from tests.utils import DEFAULT_CRS, EPSG_3067, EPSG_4326, QGIS_VERSION
+from tests.utils import EPSG_3067, EPSG_4326, QGIS_VERSION
 
 QGIS_3_12 = 31200
 
 
 @pytest.fixture()
 def crs():
-    QgsProject.instance().setCrs(DEFAULT_CRS)
+    QgsProject.instance().setCrs(QgsCoordinateReferenceSystem(EPSG_4326))
 
 
 @pytest.fixture()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@
 #
 import os
 
-from qgis.core import Qgis, QgsCoordinateReferenceSystem
+from qgis.core import Qgis
 
 try:
     QGIS_VERSION = Qgis.versionInt()
@@ -29,6 +29,3 @@ IN_CI = os.environ.get("QGIS_IN_CI")
 
 EPSG_4326 = "EPSG:4326"
 EPSG_3067 = "EPSG:3067"
-
-DEFAULT_CRS = QgsCoordinateReferenceSystem(EPSG_4326)
-CRS_3067 = QgsCoordinateReferenceSystem(EPSG_3067)


### PR DESCRIPTION
Fixes #56 by not using any `QgsCoordinateReferenceSystem` before initialiszing `QgsApplication`.