### PR TITLE
Allow changing the map extent properly when showing the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ## Fixes
 
-* [#55](https://github.com/GispoCoding/pytest-qgis/pull/55) Allows using MagicMocks to mock layers without problems
+* [#53](https://github.com/GispoCoding/pytest-qgis/pull/53) Allow using MagicMocks to mock layers without problems
 * [#60](https://github.com/GispoCoding/pytest-qgis/pull/60) Allows using CRS properly again
-* [#62](https://github.com/GispoCoding/pytest-qgis/pull/62) Allow changing the map extent properly when showing the map
+* [#62](https://github.com/GispoCoding/pytest-qgis/pull/62) Map does no longer zoom to the first added layer upon processing the events when using `qgis_show_map` marker
 
 # Version 2.0.0 (29-11-2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 * Add `clean_qgis_layer` decorator back alongside with automatic cleaning [#45](https://github.com/GispoCoding/pytest-qgis/pull/45)
 
-
 ## Fixes
 
 * [#55](https://github.com/GispoCoding/pytest-qgis/pull/55) Allows using MagicMocks to mock layers without problems
 * [#60](https://github.com/GispoCoding/pytest-qgis/pull/60) Allows using CRS properly again
+* [#62](https://github.com/GispoCoding/pytest-qgis/pull/62) Allow changing the map extent properly when showing the map
 
 # Version 2.0.0 (29-11-2023)
 

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -317,6 +317,11 @@ def _show_qgis_dlg(common_settings: Settings, qgis_parent: QWidget) -> None:
     if not common_settings.qgis_init_disabled:
         qgis_parent.setWindowTitle("Test QGIS dialog opened by Pytest-qgis")
         qgis_parent.show()
+
+        # Process events each time layer a visible layer is added to
+        # be able to change the extent properly
+        assert _APP
+        QgsProject.instance().legendLayersAdded.connect(_APP.processEvents)
     elif common_settings.qgis_init_disabled:
         warnings.warn(
             "Cannot show QGIS map because QGIS is not initialized. "

--- a/tests/visual/test_show_map.py
+++ b/tests/visual/test_show_map.py
@@ -129,12 +129,16 @@ def test_show_map_crs_change_to_4326_2(layer_polygon, layer_points, layer_polygo
 
 
 @pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT, zoom_to_common_extent=False)
-def test_show_map_should_not_keep_the_set_extent(
+def test_map_extent_should_not_change_to_layers_extent_when_processing_events(
     layer_polygon_3067, qgis_canvas, qgis_app
 ):
+    extent_smaller_than_layer = QgsRectangle(475804, 7145949.5, 549226, 7219371.5)
+
     QgsProject.instance().addMapLayer(layer_polygon_3067)
-    qgis_canvas.setExtent(QgsRectangle(475804, 7145949.5, 549226, 7219371.5))
+    qgis_canvas.setExtent(extent_smaller_than_layer)
+
     # This triggers the map to set the extent based on the layer
     # if events are not processed after adding the layer
     qgis_app.processEvents()
-    assert qgis_canvas.extent().area() < 1e11  # noqa: PLR2004
+
+    assert qgis_canvas.extent().height() == extent_smaller_than_layer.height()

--- a/tests/visual/test_show_map.py
+++ b/tests/visual/test_show_map.py
@@ -126,3 +126,15 @@ def test_show_map_crs_change_to_4326_2(layer_polygon, layer_points, layer_polygo
     QgsProject.instance().addMapLayers(
         [layer_points, layer_polygon_3067, layer_polygon]
     )
+
+
+@pytest.mark.qgis_show_map(timeout=DEFAULT_TIMEOUT, zoom_to_common_extent=False)
+def test_show_map_should_not_keep_the_set_extent(
+    layer_polygon_3067, qgis_canvas, qgis_app
+):
+    QgsProject.instance().addMapLayer(layer_polygon_3067)
+    qgis_canvas.setExtent(QgsRectangle(475804, 7145949.5, 549226, 7219371.5))
+    # This triggers the map to set the extent based on the layer
+    # if events are not processed after adding the layer
+    qgis_app.processEvents()
+    assert qgis_canvas.extent().area() < 1e11  # noqa: PLR2004


### PR DESCRIPTION
This PR fixes a bug where adding map layer causes the map to zoom to its whole extent even though the extent is changed after adding the layer.

This should be merged after #60 (CI changes) and  added to the upcoming release.