### PR TITLE
Fix QgisBot.get_qgs_attribute_dialog_widgets_by_name on QGIS 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Fixes
+
+* Fix `QgisBot.get_qgs_attribute_dialog_widgets_by_name` returning an empty
+  dict on QGIS 4.1+
+
 # Version 4.0.1 (01-04-2026)
 
 ## Fixes

--- a/src/pytest_qgis/qgis_bot.py
+++ b/src/pytest_qgis/qgis_bot.py
@@ -161,7 +161,6 @@ class QgisBot:
             if (
                 isinstance(child, QLabel)
                 and child.text() != ""
-                and child.toolTip() != ""
                 and child.buddy() is not None
             ):
                 widgets_by_name[child.text()] = child.buddy()


### PR DESCRIPTION
<!--
Thank you for contributing to an OSGeo Suomi project!

Please write this description yourself. Translation or copy-editing tools are
fine, pasting LLM output as your design rationale is not. See CONTRIBUTING.md.
-->

## Summary

This PR fixes `QgisBot.get_qgs_attribute_dialog_widgets_by_name` on QGIS 4.1 since there tooltip is non-empty.


## Related issues

<!-- e.g. Fixes #123, Refs #456 -->

## How this was tested

Tests were run locally as well as in QGIS 4.1 container.

## Contributor checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/osgeosuomi/.github/blob/main/CONTRIBUTING.md).
- [x] **I have reviewed and understand every change in this pull request, and I take responsibility for it as the author.** This applies whether the changes were written by hand or with the assistance of AI tools.
- [x] If AI tools were used to generate a substantial part of this contribution, I have disclosed it in the PR description above or via an `Assisted-by:` commit trailer.
- [x] My contribution is licensed under the same license as this repository, and I have the right to submit it.
- [x] I have run the project's tests locally where applicable.
