### PR TITLE
Flush events only after fixture finalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Fixes
+
+* Flush events only after fixture finalizers
 
 # Version 4.1.0 (04-08-2026)
 

--- a/src/pytest_qgis/pytest_qgis.py
+++ b/src/pytest_qgis/pytest_qgis.py
@@ -23,6 +23,7 @@ import shutil
 import sys
 import warnings
 from collections import namedtuple
+from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -198,15 +199,25 @@ def pytest_configure(config: "Config") -> None:
     _start_and_configure_qgis_app(config)
 
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> None:  # noqa: ARG001
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_teardown(
+    item: pytest.Item,
+    nextitem: pytest.Item | None,
+) -> Generator[None, None, None]:
     request = item.funcargs.get("request")
     if request:
         ensure_qgis_layer_fixtures_are_cleaned(request)
 
-    # Flush queued events so they cannot fire during the next test
-    if QCoreApplication.instance() is not None:
-        process_events()
+    try:
+        yield
+    finally:
+        # Flush queued events after fixture finalizers have run so they
+        # cannot fire during the next test. This must happen after the
+        # finalizers since pytest-qt has already called deleteLater() on
+        # qtbot-added widgets, and delivering DeferredDelete any earlier
+        # would destroy widgets that finalizers may still touch.
+        if nextitem is not None and QCoreApplication.instance() is not None:
+            process_events()
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
## Summary

This PR fixes the problems introduced by 8fa16c8817d73d284ad29a3b2c9c2ed5f14a0499 together with pytest-qt where widgets might get deleted too early. Now events are flushed only after fixture finalizers.

## Related issues

<!-- e.g. Fixes #123, Refs #456 -->

## How this was tested

By running tests and also downstream project tests.

## Contributor checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/osgeosuomi/.github/blob/main/CONTRIBUTING.md).
- [x] **I have reviewed and understand every change in this pull request, and I take responsibility for it as the author.** This applies whether the changes were written by hand or with the assistance of AI tools.
- [x] If AI tools were used to generate a substantial part of this contribution, I have disclosed it in the PR description above or via an `Assisted-by:` commit trailer.
- [x] My contribution is licensed under the same license as this repository, and I have the right to submit it.
- [x] I have run the project's tests locally where applicable.
